### PR TITLE
Extends Profile Viewer to allow pointing at a local folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+profileViewerDist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 script:
   - npm run build
   - npm run test
+  - npm run lint
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ cache:
     - node_modules
 
 script:
-  - npm run build
-  - npm run test
-  - npm run lint
+  - npm run travis
 
 deploy:
   provider: pages

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "MotionControllers"
   ],
   "scripts": {
-    "clean": "rm -r dist && rm -r profileViewerDist",
+    "clean": "rm -r dist 2> /dev/null & rm -r profileViewerDist 2> /dev/null || true",
     "build": "rollup -c",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server -c-1 -p 8080\"",
-    "lint": "eslint ./",
+    "lintAll": "eslint ./",
     "test": "jest",
-    "travis": "npm run clean && npm run build && npm run test && npm run lint",
+    "travis": "npm run clean && npm run build && npm run test",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {},
@@ -94,7 +94,7 @@
         "displayName": "eslint",
         "runner": "jest-runner-eslint",
         "testMatch": [
-          "<rootDir>/jestSetup/**.js",
+          "<rootDir>/testHelpers/**.js",
           "<rootDir>/**/*.test.js"
         ]
       }

--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
     "MotionControllers"
   ],
   "scripts": {
-    "clean": "rm -r dist",
+    "clean": "rm -r dist && rm -r profileViewerDist",
     "build": "rollup -c",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server -c-1 -p 8080\"",
     "lint": "eslint ./",
     "test": "jest",
+    "travis": "npm run clean && npm run build && npm run test && npm run lint",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {},

--- a/profileViewer/buildElements.js
+++ b/profileViewer/buildElements.js
@@ -75,6 +75,7 @@ function build(controller) {
     }
 
     const listElement = document.createElement('li');
+    listElement.setAttribute('class', 'component');
     listElement.innerHTML = innerHtml;
     controlsListElement.appendChild(listElement);
 

--- a/profileViewer/errorLogging.js
+++ b/profileViewer/errorLogging.js
@@ -6,14 +6,14 @@ function toggleVisibility() {
   errorsElement.hidden = errorsElement.children.length === 0;
 }
 
-function addErrorElement(errorMessage){
+function addErrorElement(errorMessage) {
   const errorsElement = document.getElementById(errorsElementId);
   if (!listElement) {
     listElement = document.createElement('ul');
     errorsElement.appendChild(listElement);
   }
 
-  let itemElement = document.createElement('li');
+  const itemElement = document.createElement('li');
   itemElement.innerText = errorMessage;
   listElement.appendChild(itemElement);
 
@@ -34,7 +34,7 @@ const ErrorLogging = {
   },
 
   clear: () => {
-    if (listElement){
+    if (listElement) {
       const errorsElement = document.getElementById(errorsElementId);
       errorsElement.removeChild(listElement);
       listElement = undefined;
@@ -48,6 +48,6 @@ const ErrorLogging = {
     listElement = undefined;
     toggleVisibility();
   }
-}
+};
 
 export default ErrorLogging;

--- a/profileViewer/errorLogging.js
+++ b/profileViewer/errorLogging.js
@@ -1,0 +1,53 @@
+const errorsElementId = 'errors';
+let listElement;
+
+function toggleVisibility() {
+  const errorsElement = document.getElementById(errorsElementId);
+  errorsElement.hidden = errorsElement.children.length === 0;
+}
+
+function addErrorElement(errorMessage){
+  const errorsElement = document.getElementById(errorsElementId);
+  if (!listElement) {
+    listElement = document.createElement('ul');
+    errorsElement.appendChild(listElement);
+  }
+
+  let itemElement = document.createElement('li');
+  itemElement.innerText = errorMessage;
+  listElement.appendChild(itemElement);
+
+  toggleVisibility();
+}
+
+const ErrorLogging = {
+  log: (errorMessage) => {
+    addErrorElement(errorMessage);
+
+    /* eslint-disable-next-line no-console */
+    console.error(errorMessage);
+  },
+
+  throw: (errorMessage) => {
+    addErrorElement(errorMessage);
+    throw new Error(errorMessage);
+  },
+
+  clear: () => {
+    if (listElement){
+      const errorsElement = document.getElementById(errorsElementId);
+      errorsElement.removeChild(listElement);
+      listElement = undefined;
+    }
+    toggleVisibility();
+  },
+
+  clearAll: () => {
+    const errorsElement = document.getElementById(errorsElementId);
+    errorsElement.innerHTML = '';
+    listElement = undefined;
+    toggleVisibility();
+  }
+}
+
+export default ErrorLogging;

--- a/profileViewer/index.html
+++ b/profileViewer/index.html
@@ -10,12 +10,18 @@
         <h1>WebXR Input Profile Viewer</h1>
         <main id="gamepad">
             <section class="selectors">
+                <label for="profileSelector">Select existing profile</label>
                 <select id="profileSelector">
                     <option value="loading">Loading...</option>
                 </select>
                 <select id="handednessSelector">
                     <option value="loading">Loading...</option>
                 </select>
+                <br>
+                <label for="localFilesSelector">Select custom profile</label>
+                <input id="localFilesSelector" type="file" multiple webkitdirectory>
+                <ul id="localFileNames">
+                </ul>
             </section>
             <section class="controls">
                 <ul id="controlsList">

--- a/profileViewer/index.html
+++ b/profileViewer/index.html
@@ -8,27 +8,30 @@
     </head>
     <body>
         <h1>WebXR Input Profile Viewer</h1>
-        <main id="gamepad">
-            <section class="selectors">
-                <label for="profileSelector">Select existing profile</label>
-                <select id="profileSelector">
-                    <option value="loading">Loading...</option>
-                </select>
-                <select id="handednessSelector">
-                    <option value="loading">Loading...</option>
-                </select>
-                <br>
-                <label for="localFilesSelector">Select custom profile</label>
-                <input id="localFilesSelector" type="file" multiple webkitdirectory>
-                <ul id="localFileNames">
-                </ul>
-            </section>
-            <section class="controls">
-                <ul id="controlsList">
-                </ul>
-            </section>
+        <main>
+            <div class="leftSide">
+                <section id="selectors">
+                    <label for="profileSelector">Select existing profile</label>
+                    <select id="profileSelector">
+                        <option value="loading">Loading...</option>
+                    </select>
+                    <select id="handednessSelector">
+                        <option value="loading">Loading...</option>
+                    </select>
+                    <br>
+                    <label for="localFilesSelector">Select custom profile</label>
+                    <input id="localFilesSelector" type="file" multiple webkitdirectory>
+                    <ul id="localFileNames">
+                    </ul>
+                </section>
+                <section id="errors" hidden="true">
+                </section>
+                <section id="controls">
+                    <ul id="controlsList">
+                    </ul>
+                </section>
+            </div>
             <section id="modelViewer">
-                <ul id="assetError"></ul>
                 <details class="data">
                     <summary>Data</summary>
                     <pre id="data"></pre>

--- a/profileViewer/index.html
+++ b/profileViewer/index.html
@@ -7,9 +7,9 @@
         <link rel="stylesheet" type="text/css" href="./profileViewer.css" />
     </head>
     <body>
-        <h1>WebXR Input Profile Viewer</h1>
         <main>
             <div class="leftSide">
+                <h1>WebXR Input Profile Viewer</h1>
                 <section id="selectors">
                     <label for="profileSelector">Select existing profile</label>
                     <select id="profileSelector">
@@ -18,11 +18,12 @@
                     <select id="handednessSelector">
                         <option value="loading">Loading...</option>
                     </select>
-                    <br>
-                    <label for="localFilesSelector">Select custom profile</label>
-                    <input id="localFilesSelector" type="file" multiple webkitdirectory>
-                    <ul id="localFileNames">
-                    </ul>
+                    <div id="customProfile">
+                        <label for="localFilesSelector">Select custom profile</label>
+                        <input id="localFilesSelector" type="file" multiple webkitdirectory>
+                        <ul id="localFileNames">
+                        </ul>
+                    </div>
                 </section>
                 <section id="errors" hidden="true">
                 </section>

--- a/profileViewer/modelViewer.js
+++ b/profileViewer/modelViewer.js
@@ -148,18 +148,16 @@ function animationFrameCallback() {
 
       // Skip if the component node is not found. No error is needed, because it
       // will have been reported at load time.
-      if (!componentNodes)
-        return;
+      if (!componentNodes) return;
 
       // Update node data based on the visual responses' current states
       Object.values(component.visualResponses).forEach((visualResponse) => {
         const { description, value } = visualResponse;
         const visualResponseNodes = componentNodes[description.rootNodeName];
-        
+
         // Skip if the visual response node is not found. No error is needed,
         // because it will have been reported at load time.
-        if (!visualResponseNodes)
-          return;
+        if (!visualResponseNodes) return;
 
         // Calculate the new properties based on the weight supplied
         if (description.property === 'visibility') {
@@ -245,7 +243,8 @@ const ModelViewer = {
 
     const onError = () => {
       ErrorLogging.throw(
-        `Asset failed to load either because it was missing or malformed. ${motionController.assetPath}`);
+        `Asset failed to load either because it was missing or malformed. ${motionController.assetPath}`
+      );
     };
 
     three.loader.load(

--- a/profileViewer/modelViewer.js
+++ b/profileViewer/modelViewer.js
@@ -1,23 +1,13 @@
 /* eslint import/no-unresolved: off */
 
+import ErrorLogging from './errorLogging.js';
 import * as THREE from './three/build/three.module.js';
 import { GLTFLoader } from './three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from './three/examples/jsm/controls/OrbitControls.js';
 
 const three = {};
 let canvasParentElement;
-let assetErrorElement;
 let activeModel;
-
-function logViewerError(errorMessage) {
-  let errorElement = document.createElement('li');
-  errorElement.innerText = errorMessage;
-
-  assetErrorElement.appendChild(errorElement);
-  assetErrorElement.hidden = false;
-
-  console.error(errorMessage);
-}
 
 /**
  * @description Attaches a small blue sphere to the point reported as touched on all touchpads
@@ -33,8 +23,7 @@ function addTouchDots({ motionController, rootNode }) {
       const componentRoot = rootNode.getObjectByName(component.rootNodeName, true);
 
       if (!componentRoot) {
-        // eslint-disable-next-line no-console
-        logViewerError(`Could not find root node of touchpad component ${component.rootNodeName}`);
+        ErrorLogging.log(`Could not find root node of touchpad component ${component.rootNodeName}`);
         return;
       }
 
@@ -63,8 +52,7 @@ function findNodes(model) {
 
     // If the root node cannot be found, skip this component
     if (!componentRootNode) {
-      // eslint-disable-next-line no-console
-      logViewerError(`Could not find root node of component ${component.rootNodeName}`);
+      ErrorLogging.log(`Could not find root node of component ${component.rootNodeName}`);
       return;
     }
 
@@ -82,8 +70,7 @@ function findNodes(model) {
 
       // If the root node cannot be found, skip this animation
       if (!visualResponseNodes.rootNode) {
-        // eslint-disable-next-line no-console
-        logViewerError(`Could not find root node of visual response for ${rootNodeName}`);
+        ErrorLogging.log(`Could not find root node of visual response for ${rootNodeName}`);
         return;
       }
 
@@ -98,8 +85,7 @@ function findNodes(model) {
 
         // If the extents cannot be found, skip this animation
         if (!visualResponseNodes.minNode || !visualResponseNodes.maxNode) {
-          // eslint-disable-next-line no-console
-          logViewerError(`Could not find extents nodes of visual response for ${rootNodeName}`);
+          ErrorLogging.log(`Could not find extents nodes of visual response for ${rootNodeName}`);
           return;
         }
       }
@@ -128,8 +114,7 @@ function clear() {
     activeModel = null;
   }
 
-  assetErrorElement.innerText = '';
-  assetErrorElement.hidden = true;
+  ErrorLogging.clear();
 }
 /**
  * @description Event handler for window resizing.
@@ -204,7 +189,6 @@ function animationFrameCallback() {
 const ModelViewer = {
   initialize: () => {
     canvasParentElement = document.getElementById('modelViewer');
-    assetErrorElement = document.getElementById('assetError');
     const width = canvasParentElement.clientWidth;
     const height = canvasParentElement.clientHeight;
 
@@ -260,9 +244,8 @@ const ModelViewer = {
     };
 
     const onError = () => {
-      const errorMessage = `Asset failed to load either because it was missing or malformed. ${motionController.assetPath}`;
-      logViewerError(errorMessage);
-      throw new Error(errorMessage);
+      ErrorLogging.throw(
+        `Asset failed to load either because it was missing or malformed. ${motionController.assetPath}`);
     };
 
     three.loader.load(

--- a/profileViewer/modelViewer.js
+++ b/profileViewer/modelViewer.js
@@ -241,7 +241,7 @@ const ModelViewer = {
     window.requestAnimationFrame(animationFrameCallback);
   },
 
-  loadModel: (motionController) => {
+  loadModel: (motionController, assetPath) => {
     // Remove any existing model from the scene
     clear();
 
@@ -266,7 +266,7 @@ const ModelViewer = {
     };
 
     three.loader.load(
-      motionController.assetPath,
+      (assetPath) || motionController.assetPath,
       onLoad,
       null,
       onError

--- a/profileViewer/profileViewer.css
+++ b/profileViewer/profileViewer.css
@@ -3,6 +3,10 @@
   margin: 0;
 }
 
+h1 {
+  padding-bottom: .5em;
+}
+
 .leftSide {
   width: calc(50% - 2em);
   padding: 1em;
@@ -39,4 +43,13 @@ section {
   width: 50%;
   right: 0;
   top: 0;
+}
+
+#customProfile {
+  margin-top: .5em;
+}
+
+#customProfile ul {
+  margin-left: .5em;
+  list-style: inside;
 }

--- a/profileViewer/profileViewer.css
+++ b/profileViewer/profileViewer.css
@@ -1,21 +1,42 @@
-#modelViewer {
-  width: 50%;
-  height: 100vw;
-  position: absolute;
-  right: 0;
-  top: 0;
+* {
   padding: 0;
   margin: 0;
 }
 
-#assetError {
+.leftSide {
+  width: calc(50% - 2em);
+  padding: 1em;
+}
+
+section {
+  margin-bottom: 1em;
+}
+
+.component {
+  border: 1px dashed black;
+  list-style: none;
+  margin-top: .25em;
+  margin-bottom: .25em;
+  padding: .5em;
+}
+
+#errors {
   background-color: white;
   border: solid black;
   color: red;
+  margin: .5em;
+  margin-bottom: 1em;
+}
+
+#errors ul {
+  margin: 0.5em;
+  list-style-position: inside;
+}
+
+#modelViewer {
+  height: 100vw;
   position: absolute;
-  right: 1em;
-  left: 1em;
-  top: 1em;
-  display: block;
-  z-index: 100;
+  width: 50%;
+  right: 0;
+  top: 0;
 }

--- a/profileViewer/profileViewer.js
+++ b/profileViewer/profileViewer.js
@@ -4,6 +4,7 @@ import { Profiles } from '../dist/webxr-input-profiles.module.js';
 import { MockGamepad, MockXRInputSource } from '../dist/webxr-input-mocks.module.js';
 import ModelViewer from './modelViewer.js';
 import ManualControls from './buildElements.js';
+import ErrorLogging from './errorLogging.js';
 
 const profiles = new Profiles('../dist/profiles');
 
@@ -19,6 +20,7 @@ let activeProfile;
 let customProfileAssets = {};
 
 function clear(saveProfile) {
+  ErrorLogging.clearAll();
   ModelViewer.clear();
   ManualControls.clear();
   if (!saveProfile) {
@@ -124,9 +126,7 @@ function loadCustomFiles(queryStringHandedness) {
 
   if (!profileFile) {
     enableInteraction();
-    // TODO move the error logger into its own file so I can log errors from this file too
-    console.log('No profile.json');
-    throw new Error('No profile.json');
+    ErrorLogging.log('No profile.json');
   }
 
   // Attempt to load the profile
@@ -139,9 +139,7 @@ function loadCustomFiles(queryStringHandedness) {
 
   reader.onerror = () => {
     enableInteraction();
-    // TODO move the error logger into its own file so I can log errors from this file too
-    console.log('Unable to load profile.json');
-    throw new Error('Unable to load profile.json');
+    ErrorLogging.logAndThrow('Unable to load profile.json');
   };
 
   reader.readAsText(profileFile);
@@ -172,7 +170,7 @@ function onProfileIdSelected(queryStringHandedness) {
       })
       .catch((error) => {
         enableInteraction();
-        console.error(error);
+        ErrorLogging.log(error.message);
         throw error;
       });
   }

--- a/rollup-plugin-profiles.js
+++ b/rollup-plugin-profiles.js
@@ -37,7 +37,7 @@ export default function generateProfilesList({ profilePaths, dest, watch } = {})
     name: 'buildProfilesList',
     buildStart: async () => {
       // Get the profilesList
-      const filePaths = await globby(profilePaths + '/*.json');
+      const filePaths = await globby(`${profilePaths}/*.json`);
       filePaths.forEach((filePath) => {
         profilesList[filePath] = path.basename(path.dirname(filePath));
       });

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,7 @@ export default [
       copy(
         [
           { files: 'profiles/**', dest: `${DIST_FOLDER}/profiles` },
-          { files: 'profileViewer/**', dest: `${VIEWER_FOLDER}`}
+          { files: 'profileViewer/**', dest: `${VIEWER_FOLDER}` }
         ],
         { verbose: true, watch: process.env.ROLLUP_WATCH }
       ),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,19 +15,12 @@ export default [
       }
     ],
     plugins: [
-      eslint(),
+      eslint({ throwOnError: true }),
       copy(
         [
-          { files: 'profiles/**', dest: `${DIST_FOLDER}/profiles` },
-          { files: 'profileViewer/**', dest: `${VIEWER_FOLDER}` }
+          { files: 'profiles/**', dest: `${DIST_FOLDER}/profiles` }
         ],
         { verbose: true, watch: process.env.ROLLUP_WATCH }
-      ),
-      copy(
-        [
-          { files: 'node_modules/three/**', dest: `${VIEWER_FOLDER}/three` }
-        ],
-        { verbose: false, watch: process.env.ROLLUP_WATCH }
       ),
       buildProfilesList({
         profilePaths: ['profiles/**'],
@@ -44,6 +37,40 @@ export default [
         format: 'es',
         file: `${DIST_FOLDER}/webxr-input-mocks.module.js`
       }
+    ],
+    plugins: [
+      eslint({ throwOnError: true })
+    ]
+  },
+  {
+    input: ['profileViewer/profileViewer.js'],
+    output: [
+      {
+        format: 'es',
+        file: `${VIEWER_FOLDER}/profileViewer.js`
+      }
+    ],
+    external: [
+      './three/build/three.module.js',
+      './three/examples/jsm/loaders/GLTFLoader.js',
+      './three/examples/jsm/controls/OrbitControls.js',
+      '../dist/webxr-input-profiles.module.js',
+      '../dist/webxr-input-mocks.module.js'
+    ],
+    plugins: [
+      eslint({ throwOnError: true }),
+      copy(
+        [
+          { files: 'profileViewer/*.{html,css}', dest: `${VIEWER_FOLDER}` }
+        ],
+        { verbose: true, watch: process.env.ROLLUP_WATCH }
+      ),
+      copy(
+        [
+          { files: 'node_modules/three/**', dest: `${VIEWER_FOLDER}/three` }
+        ],
+        { verbose: false, watch: process.env.ROLLUP_WATCH }
+      )
     ]
   }
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default [
         profilePaths: ['profiles/**'],
         dest: `${DIST_FOLDER}/profiles/profilesList.json`,
         verbose: true,
-        watch: process.env.ROLLUP_WATCH 
+        watch: process.env.ROLLUP_WATCH
       })
     ]
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import copy from 'rollup-plugin-copy-glob';
 import buildProfilesList from './rollup-plugin-profiles';
 
 const DIST_FOLDER = 'dist';
-const VIEWER_FOLDER = 'profileViewer';
+const VIEWER_FOLDER = 'profileViewerDist';
 
 export default [
   {
@@ -19,9 +19,15 @@ export default [
       copy(
         [
           { files: 'profiles/**', dest: `${DIST_FOLDER}/profiles` },
-          { files: 'node_modules/three/**', dest: `${VIEWER_FOLDER}/three` }
+          { files: 'profileViewer/**', dest: `${VIEWER_FOLDER}`}
         ],
         { verbose: true, watch: process.env.ROLLUP_WATCH }
+      ),
+      copy(
+        [
+          { files: 'node_modules/three/**', dest: `${VIEWER_FOLDER}/three` }
+        ],
+        { verbose: false, watch: process.env.ROLLUP_WATCH }
       ),
       buildProfilesList({
         profilePaths: ['profiles/**'],

--- a/src/motionController.js
+++ b/src/motionController.js
@@ -56,7 +56,13 @@ class MotionController {
   }
 
   get assetPath() {
-    return `${this.profile.baseUri}/${this.hand.asset}`;
+    let assetPath;
+    if (this.profile.baseUri) {
+      assetPath = `${this.profile.baseUri}/${this.hand.asset}`;
+    } else {
+      assetPath = this.hand.asset;
+    }
+    return assetPath;
   }
 
   get gripSpace() {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -93,6 +93,16 @@ class Profiles {
     const motionController = new MotionController(xrInputSource, profile);
     return motionController;
   }
+
+  /**
+   * @description Create a MotionController from an XRInputSource
+   * @param {Object} xrInputSource - The input source to build a MotionController from
+   * @param {Object} profile - The custom profile to use
+   */
+  static createCustomMotionController(xrInputSource, profile) {
+    const motionController = new MotionController(xrInputSource, profile);
+    return motionController;
+  }
 }
 
 export default Profiles;


### PR DESCRIPTION
This PR includes a handful of quality of life improvements.  
* profileViewer page is now able to load files from a local folder to test from. In Firefox, the selected file list is persisted on refresh; in Chrome it is not.  In either case, the 'custom' profile value is saved on the query string.
* Moves the profileViewer to deploy into its own distribution folder so that the build doesn't copy three.js into a source folder.
* Three.js file copies during the build are no longer verbose
* Added a file to manage error logging and display across all JavaScript files in the profileViewer
* Cleaned up the CSS so that errors are always legible and the error box is properly hidden when no errors are present
* Makes sure travis runs linting across all files not just tests and those in src/
* Adds a package.json script to simulate running travis