### PR TITLE
Remove the special case for button min/max node name defaults

### DIFF
--- a/profiles/WebVR Spatial Controller (Spatial Interaction Source) 045E-065D/profile.json
+++ b/profiles/WebVR Spatial Controller (Spatial Interaction Source) 045E-065D/profile.json
@@ -87,12 +87,16 @@
         {
             "rootNodeName" : "SELECT",
             "source" : "buttonValue",
-            "states" : ["default", "touched", "pressed"]
+            "states" : ["default", "touched", "pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "THUMBSTICK_PRESS",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "THUMBSTICK_X",
@@ -107,12 +111,16 @@
         {
             "rootNodeName" : "GRASP",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "TOUCHPAD_PRESS",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "TOUCH",
@@ -133,7 +141,9 @@
         {
             "rootNodeName" : "MENU",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         }
     ]
 }

--- a/profiles/microsoft-045e-065d/profile.json
+++ b/profiles/microsoft-045e-065d/profile.json
@@ -84,12 +84,16 @@
         {
             "rootNodeName" : "SELECT",
             "source" : "buttonValue",
-            "states" : ["default", "touched", "pressed"]
+            "states" : ["default", "touched", "pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "THUMBSTICK_PRESS",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "THUMBSTICK_X",
@@ -104,12 +108,16 @@
         {
             "rootNodeName" : "GRASP",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "TOUCHPAD_PRESS",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         },
         {
             "rootNodeName": "TOUCH",
@@ -130,7 +138,9 @@
         {
             "rootNodeName" : "MENU",
             "source" : "state",
-            "states" : ["pressed"]
+            "states" : ["pressed"],
+            "minNodeName": "UNPRESSED",
+            "maxNodeName": "PRESSED"
         }
     ]
 }

--- a/src/__tests__/visualResponse.test.js
+++ b/src/__tests__/visualResponse.test.js
@@ -19,11 +19,8 @@ describe('Construction tests', () => {
     }).toThrow();
   });
   test.each([
-    ['buttonValue', 'PRESSED', 'UNPRESSED'],
-    ['state', 'PRESSED', 'UNPRESSED'],
-    ['xAxis', 'MAX', 'MIN'],
-    ['yAxis', 'MAX', 'MIN']
-  ])('Create with %s source and no additional properties', (source, minNodeName, maxNodeName) => {
+    ['buttonValue', 'state', 'xAxis', 'yAxis']
+  ])('Create with %s source and no additional properties', (source) => {
     const responseDescription = {
       rootNodeName: 'ROOT',
       source,
@@ -32,8 +29,8 @@ describe('Construction tests', () => {
 
     const expectedResponse = Object.assign(responseDescription, {
       targetNodeName: 'ROOT',
-      minNodeName,
-      maxNodeName,
+      minNodeName: 'MIN',
+      maxNodeName: 'MAX',
       property: 'transform'
     });
 

--- a/src/visualResponse.js
+++ b/src/visualResponse.js
@@ -61,14 +61,8 @@ class VisualResponse {
     }
 
     // Looks for min/max node names and sets defaults if they are not defined
-    // TODO: Button and state responses have different named values, though this should be changed
-    if (this.description.source === 'buttonValue' || this.description.source === 'state') {
-      this.description.maxNodeName = (this.description.maxNodeName) ? this.description.maxNodeName : 'PRESSED';
-      this.description.minNodeName = (this.description.minNodeName) ? this.description.minNodeName : 'UNPRESSED';
-    } else {
-      this.description.maxNodeName = (this.description.maxNodeName) ? this.description.maxNodeName : 'MAX';
-      this.description.minNodeName = (this.description.minNodeName) ? this.description.minNodeName : 'MIN';
-    }
+    this.description.maxNodeName = (this.description.maxNodeName) ? this.description.maxNodeName : 'MAX';
+    this.description.minNodeName = (this.description.minNodeName) ? this.description.minNodeName : 'MIN';
 
     // Looks for the property name and sets a default if it is not defined
     this.description.property = (this.description.property) ? this.description.property : 'transform';


### PR DESCRIPTION
Nothing much more to explain here.  VisualResponse min/max nodes always default to "MIN"/"MAX" and the non-standard node names have been added to the profile.json for the windows controllers.