### PR TITLE
Fix issues for Oculus Touch, HTC Vive, and WMR controller entries

### DIFF
--- a/packages/profiles-registry/profiles/htc-vive/profile.json
+++ b/packages/profiles-registry/profiles/htc-vive/profile.json
@@ -44,13 +44,6 @@
     ],
     "dataSources" : [
         {
-            "id" : "trackpad",
-            "dataSourceType": "touchpadSource",
-            "xAxisIndex" : 0,
-            "yAxisIndex" : 1,
-            "buttonIndex" : 2
-        },
-        {
             "id" : "trigger",
             "dataSourceType": "buttonSource",
             "buttonIndex" : 0,
@@ -60,6 +53,13 @@
             "id" : "grip",
             "dataSourceType": "buttonSource",
             "buttonIndex" : 1
+        },
+        {
+            "id" : "trackpad",
+            "dataSourceType": "touchpadSource",
+            "xAxisIndex" : 0,
+            "yAxisIndex" : 1,
+            "buttonIndex" : 2
         }
     ],
     "visualResponses" : [

--- a/packages/profiles-registry/profiles/htc-vive/profile.json
+++ b/packages/profiles-registry/profiles/htc-vive/profile.json
@@ -48,18 +48,18 @@
             "dataSourceType": "touchpadSource",
             "xAxisIndex" : 0,
             "yAxisIndex" : 1,
-            "buttonIndex" : 0
+            "buttonIndex" : 2
         },
         {
             "id" : "trigger",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 1,
+            "buttonIndex" : 0,
             "analogValues" : true
         },
         {
             "id" : "grip",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 2
+            "buttonIndex" : 1
         }
     ],
     "visualResponses" : [

--- a/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
+++ b/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
@@ -57,15 +57,15 @@
         {
             "id" : "touchpad",
             "dataSourceType": "touchpadSource",
-            "xAxisIndex" : 2,
-            "yAxisIndex" : 3,
+            "xAxisIndex" : 0,
+            "yAxisIndex" : 1,
             "buttonIndex" : 2
         },
         {
             "id" : "thumbstick",
             "dataSourceType": "thumbstickSource",
-            "xAxisIndex" : 0,
-            "yAxisIndex" : 1,
+            "xAxisIndex" : 2,
+            "yAxisIndex" : 3,
             "buttonIndex" : 3
         }
     ],

--- a/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
+++ b/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
@@ -56,13 +56,6 @@
             "analogValues": true
         },
         {
-            "id" : "thumbstick",
-            "dataSourceType": "thumbstickSource",
-            "xAxisIndex" : 0,
-            "yAxisIndex" : 1,
-            "buttonIndex" : 3
-        },
-        {
             "id" : "grip",
             "dataSourceType": "buttonSource",
             "buttonIndex" : 1
@@ -73,6 +66,13 @@
             "xAxisIndex" : 2,
             "yAxisIndex" : 3,
             "buttonIndex" : 2
+        },
+        {
+            "id" : "thumbstick",
+            "dataSourceType": "thumbstickSource",
+            "xAxisIndex" : 0,
+            "yAxisIndex" : 1,
+            "buttonIndex" : 3
         },
         {
             "id" : "menu",

--- a/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
+++ b/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
@@ -60,19 +60,19 @@
             "dataSourceType": "thumbstickSource",
             "xAxisIndex" : 0,
             "yAxisIndex" : 1,
-            "buttonIndex" : 1
+            "buttonIndex" : 3
         },
         {
             "id" : "grip",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 2
+            "buttonIndex" : 1
         },
         {
             "id" : "touchpad",
             "dataSourceType": "touchpadSource",
             "xAxisIndex" : 2,
             "yAxisIndex" : 3,
-            "buttonIndex" : 3
+            "buttonIndex" : 2
         },
         {
             "id" : "menu",

--- a/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
+++ b/packages/profiles-registry/profiles/microsoft-045e-065d/profile.json
@@ -5,13 +5,13 @@
         "left" : {
             "asset" : "left.glb",
             "root" : "left-controller-node",
-            "components" : [ 0, 1, 2, 3, 4],
+            "components" : [ 0, 1, 2, 3],
             "selectionComponent" : 0
         },
         "right" : {
             "asset" : "right.glb",
             "root" : "right-controller-node",
-            "components" : [ 0, 1, 2, 3, 4],
+            "components" : [ 0, 1, 2, 3],
             "selectionComponent" : 0
         }
     },
@@ -40,12 +40,6 @@
             "labelTransform" : "grip-label",
             "visualResponses": [5, 6, 7, 8],
             "touchpadDot" : "TOUCH"
-        },
-        {
-            "dataSource" : 4,
-            "root" : "MENU",
-            "labelTransform" : "menu-label",
-            "visualResponses": [9]
         }
     ],
     "dataSources" : [
@@ -73,11 +67,6 @@
             "xAxisIndex" : 0,
             "yAxisIndex" : 1,
             "buttonIndex" : 3
-        },
-        {
-            "id" : "menu",
-            "dataSourceType": "buttonSource",
-            "buttonIndex" : 4
         }
     ],
     "visualResponses" : [
@@ -134,13 +123,6 @@
             "rootNodeName": "TOUCHPAD_TOUCH_Y",
             "source" : "yAxis",
             "states" : ["default", "touched", "pressed"]
-        },
-        {
-            "rootNodeName" : "MENU",
-            "source" : "state",
-            "states" : ["pressed"],
-            "minNodeName": "UNPRESSED",
-            "maxNodeName": "PRESSED"
         }
     ]
 }

--- a/packages/profiles-registry/profiles/oculus-touch/profile.json
+++ b/packages/profiles-registry/profiles/oculus-touch/profile.json
@@ -80,8 +80,8 @@
         {
             "id" : "thumbstick",
             "dataSourceType": "thumbstickSource",
-            "xAxisIndex" : 0,
-            "yAxisIndex" : 1,
+            "xAxisIndex" : 2,
+            "yAxisIndex" : 3,
             "buttonIndex" : 3
         },
         {

--- a/packages/profiles-registry/profiles/oculus-touch/profile.json
+++ b/packages/profiles-registry/profiles/oculus-touch/profile.json
@@ -67,13 +67,6 @@
     ],
     "dataSources" : [
         {
-            "id" : "thumbstick",
-            "dataSourceType": "thumbstickSource",
-            "xAxisIndex" : 0,
-            "yAxisIndex" : 1,
-            "buttonIndex" : 3
-        },
-        {
             "id" : "trigger",
             "dataSourceType": "buttonSource",
             "buttonIndex" : 0,
@@ -83,6 +76,13 @@
             "id" : "grip",
             "dataSourceType": "buttonSource",
             "buttonIndex" : 1
+        },
+        {
+            "id" : "thumbstick",
+            "dataSourceType": "thumbstickSource",
+            "xAxisIndex" : 0,
+            "yAxisIndex" : 1,
+            "buttonIndex" : 3
         },
         {
             "id" : "x",

--- a/packages/profiles-registry/profiles/oculus-touch/profile.json
+++ b/packages/profiles-registry/profiles/oculus-touch/profile.json
@@ -71,43 +71,43 @@
             "dataSourceType": "thumbstickSource",
             "xAxisIndex" : 0,
             "yAxisIndex" : 1,
-            "buttonIndex" : 0
+            "buttonIndex" : 3
         },
         {
             "id" : "trigger",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 1,
+            "buttonIndex" : 0,
             "analogValues" : true
         },
         {
             "id" : "grip",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 2
+            "buttonIndex" : 1
         },
         {
             "id" : "x",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 3
+            "buttonIndex" : 4
         },
         {
             "id" : "y",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 4
+            "buttonIndex" : 5
         },
         {
             "id" : "a",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 3
+            "buttonIndex" : 4
         },
         {
             "id" : "b",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 4
+            "buttonIndex" : 5
         },
         {
             "id" : "thumbrest",
             "dataSourceType": "buttonSource",
-            "buttonIndex" : 5,
+            "buttonIndex" : 6,
             "pressUnsupported": true
         }
     ],


### PR DESCRIPTION
Update the profiles for these controllers to reflect the order that buttons and input axes should be exposed to the JS with the latest xr-standard Gamepad mapping, which is explained [here](https://github.com/immersive-web/webxr-gamepads-module/blob/master/gamepads-module-explainer.md).

Also remove the entry for the menu button from the microsoft-045e-065d profile (which happens to be the Samsung Odyssey) because the spec says buttons reserved by the UA and/or platform must not be exposed.