### PR TITLE
Potential registry format

### DIFF
--- a/src/profiles/registry.json
+++ b/src/profiles/registry.json
@@ -1,0 +1,28 @@
+{
+    "genericProfiles" : [
+        "button-controller", 
+        "thumbstick-controller", 
+        "touchpad-controller", 
+        "thumbstick-touchpad-controller"
+    ],
+    "customProfiles" : {
+        "google-daydream" : [ "touchpad-controller" ],
+        "htc-vive" : [ "touchpad-controller" ],
+        "microsoft-045e-065d" : [ "thumbstick-touchpad-controller" ],
+        "microsoft-045e-065b" : [ "microsoft-045e-065d", "thumbstick-touchpad-controller" ],
+        "oculus-go" : [ "touchpad-controller"],
+        "oculus-quest" : [ "oculus-touch", "oculus-go", "thumbstick-controller" ],
+        "oculus-touch" : [ "thumbstick-controller" ],
+        "samsung-gearvr" : [ "touchpad-controller" ],
+        "valve-index" : [ "htc-vive", "touchpad-controller" ]
+    },
+    "legacyWebVRProfiles" : [ 
+        "Daydream Controller",
+        "Oculus Go Controller", 
+        "Oculus Touch (Left)", 
+        "Oculus Touch (Right)", 
+        "OpenVR Gamepad",
+        "Spatial Controller (Spatial Interaction Source) O45E-065B",
+        "Spatial Controller (Spatial Interaction Source) O45E-065D"
+    ]
+}


### PR DESCRIPTION
A really early stab at how we might define the registry.  This will probably end up moving into a different folder, but for now...

I put three sections in the json.  The first, is the list of agreed up on generic profiles.  The third is the legacy controller names for WebVR.  

The interesting part is the second section.  "customProfiles" is a terrible name, but in the interest of not getting stuck in the weeds bikeshedding.... the important bit here is that I've got an entry for each hardware device.  That entry's value is an array of the strings.  The XRInputSource.profiles[0] will be the custom profile key and all the subsequent XRInputSource.profiles elements will be the values of the custom profiles array in order. 

A few questions that come to mind...
* Do we want to make a requirement that each customProfile entry must end in a generic profile?  
* Do we want to make a requirement that there only be one generic profile in each custom profile's list?
* Should we remove the webvr legacy elements?
* Should we not bother separating the generic profiles at all?

Lots to think about.