### PR TITLE
Rename grip->squeeze

### DIFF
--- a/packages/assets/profiles/generic/generic-trigger-squeeze-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-thumbstick.json
@@ -1,5 +1,5 @@
 {
-    "profileId" : "generic-trigger-grip-thumbstick",
+    "profileId" : "generic-trigger-squeeze-thumbstick",
     "assets" : {
         "none" : {
             "path" : "some-url",
@@ -28,9 +28,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
-                    "rootNodeName" : "grip-node",
-                    "labelAnchorNodeName" : "grip-label-transform",
+                "xr-standard-squeeze": {
+                    "rootNodeName" : "squeeze-node",
+                    "labelAnchorNodeName" : "squeeze-label-transform",
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
@@ -1,5 +1,5 @@
 {
-    "profileId" : "generic-trigger-grip-touchpad-thumbstick",
+    "profileId" : "generic-trigger-squeeze-touchpad-thumbstick",
     "assets" : {
         "none" : {
             "path" : "some-url",
@@ -28,9 +28,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
-                    "rootNodeName" : "grip-node",
-                    "labelAnchorNodeName" : "grip-label-transform",
+                "xr-standard-squeeze": {
+                    "rootNodeName" : "squeeze-node",
+                    "labelAnchorNodeName" : "squeeze-label-transform",
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad.json
@@ -1,5 +1,5 @@
 {
-    "profileId" : "generic-trigger-grip-touchpad",
+    "profileId" : "generic-trigger-squeeze-touchpad",
     "assets" : {
         "none" : {
             "path" : "some-url",
@@ -28,9 +28,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
-                    "rootNodeName" : "grip-node",
-                    "labelAnchorNodeName" : "grip-label-transform",
+                "xr-standard-squeeze": {
+                    "rootNodeName" : "squeeze-node",
+                    "labelAnchorNodeName" : "squeeze-label-transform",
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",

--- a/packages/assets/profiles/generic/generic-trigger-squeeze.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze.json
@@ -1,5 +1,5 @@
 {
-    "profileId" : "generic-trigger-grip",
+    "profileId" : "generic-trigger-squeeze",
     "assets" : {
         "none" : {
             "path" : "some-url",
@@ -28,9 +28,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
-                    "rootNodeName" : "grip-node",
-                    "labelAnchorNodeName" : "grip-label-transform",
+                "xr-standard-squeeze": {
+                    "rootNodeName" : "squeeze-node",
+                    "labelAnchorNodeName" : "squeeze-label-transform",
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",

--- a/packages/assets/profiles/htc/htc-vive.json
+++ b/packages/assets/profiles/htc/htc-vive.json
@@ -29,9 +29,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -42,7 +42,7 @@
                 },
                 "xr-standard-touchpad": {
                     "rootNodeName" : "TOUCHPAD_PRESS",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "touchPointNodeName" : "TOUCH",
                     "visualResponses": [
                         {

--- a/packages/assets/profiles/microsoft/microsoft-mixed-reality.json
+++ b/packages/assets/profiles/microsoft/microsoft-mixed-reality.json
@@ -27,9 +27,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -42,7 +42,7 @@
                 },
                 "xr-standard-touchpad": {
                     "rootNodeName" : "TOUCHPAD_PRESS",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "touchPointNodeName" : "TOUCH",
                     "visualResponses": [
                         {

--- a/packages/assets/profiles/oculus/oculus-quest.json
+++ b/packages/assets/profiles/oculus/oculus-quest.json
@@ -27,9 +27,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -103,9 +103,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",

--- a/packages/assets/profiles/oculus/oculus-touch-s.json
+++ b/packages/assets/profiles/oculus/oculus-touch-s.json
@@ -27,9 +27,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -103,9 +103,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",

--- a/packages/assets/profiles/oculus/oculus-touch.json
+++ b/packages/assets/profiles/oculus/oculus-touch.json
@@ -27,9 +27,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -115,9 +115,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",

--- a/packages/assets/profiles/samsung/samsung-gearvr.json
+++ b/packages/assets/profiles/samsung/samsung-gearvr.json
@@ -23,7 +23,7 @@
                 },
                 "xr-standard-touchpad": {
                     "rootNodeName" : "TOUCHPAD_PRESS",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "touchPointNodeName" : "TOUCH",
                     "visualResponses": [
                         {

--- a/packages/assets/profiles/samsung/samsung-odyssey.json
+++ b/packages/assets/profiles/samsung/samsung-odyssey.json
@@ -27,9 +27,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -42,7 +42,7 @@
                 },
                 "xr-standard-touchpad": {
                     "rootNodeName" : "TOUCHPAD_PRESS",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "touchPointNodeName" : "TOUCH",
                     "visualResponses": [
                         {

--- a/packages/assets/profiles/valve/valve-knuckles.json
+++ b/packages/assets/profiles/valve/valve-knuckles.json
@@ -27,9 +27,9 @@
                         }
                     ]
                 },
-                "xr-standard-grip": {
+                "xr-standard-squeeze": {
                     "rootNodeName" : "GRASP",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
@@ -42,7 +42,7 @@
                 },
                 "xr-standard-touchpad": {
                     "rootNodeName" : "TOUCHPAD_PRESS",
-                    "labelAnchorNodeName" : "grip-label",
+                    "labelAnchorNodeName" : "squeeze-label",
                     "touchPointNodeName" : "TOUCH",
                     "visualResponses": [
                         {

--- a/packages/motion-controllers/README.md
+++ b/packages/motion-controllers/README.md
@@ -6,13 +6,13 @@
 This package provides a 3D engine agnostic javascript library for synchronizing the status of an `XRInputSource` object with a 3D model representing that `XRInputSource`. The library consumes JSON files in the format published from the [@webxr-input-profiles/assets](../assets/README.md) package to create `MotionController` objects that enable a simple path for developers to:
 
 1. Find the best matching profile for an `XRInputSource`
-1. Enumerate the component parts (triggers, grips, touchpads, thumbsticks, buttons, etc)
+1. Enumerate the component parts (trigger, squeeze, touchpad, thumbstick, button, etc)
 1. If a 3D asset is available for the matching profile, provide a path to load it
 1. On each render frame, apply precomputed deformations to the 3D asset to reflect the state `XRInputSource`
 1. Optionally attach descriptive explanations to each component that will not overlap the rest of the 3D asset
 
 ### Background
-The state of an XR motion controller's triggers, grips, touchnpads, thumbsticks, and buttons is made available to developers via the `XRInputSource.Gamepad` object. The behavior of this object is described in [WebXR Gamepads Module](https://www.w3.org/TR/webxr-gamepads-module/) and the [Gamepad API](https://www.w3.org/TR/gamepad/). These objects expose detailed state in the `Gamepad.buttons` array and the `Gamepad.axes` array. While this system was adequate for the relatively homogenous console gaming controllers, it is less effective for XR motion controllers as they have not converged on a common form factor. In addition, the `Gamepad` object does not provide any information about the visualization of a `XRInputSource` object which is a requirement to displaying a virtual copy of motion controller on opaque XR headsets.
+The state of an XR motion controller's trigger, squeeze, touchnpad, thumbstick, and button components is made available to developers via the `XRInputSource.Gamepad` object. The behavior of this object is described in [WebXR Gamepads Module](https://www.w3.org/TR/webxr-gamepads-module/) and the [Gamepad API](https://www.w3.org/TR/gamepad/). These objects expose detailed state in the `Gamepad.buttons` array and the `Gamepad.axes` array. While this system was adequate for the relatively homogenous console gaming controllers, it is less effective for XR motion controllers as they have not converged on a common form factor. In addition, the `Gamepad` object does not provide any information about the visualization of a `XRInputSource` object which is a requirement to displaying a virtual copy of motion controller on opaque XR headsets.
 
 ### Licence
 Per the [LICENSE.md](LICENCE.md) file, this package is made available under an MIT license and is copyright Amazon 2019.
@@ -93,10 +93,10 @@ function onAnimationFrameCallback(xrFrame) {
 ```
 
 ## Components
-Once a `MotionController` has been created, developers can access interact with its components such as thumbsticks, touchpads, triggers, grips, and buttons. These components expose their current values through the `Components.values` object.  The `values.state` key will always be present and describes the overall state of the component as being `pressed`, `touched`, or `default`.  In addition to `values.state`, components may optionally also have a `values.button`, `values.xAxis`, or `values.yAxis`.  Each of values are populated slightly differently based on the underlying component type.
+Once a `MotionController` has been created, developers can access interact with its components such as thumbsticks, touchpads, triggers, squeezes, and buttons. These components expose their current values through the `Components.values` object.  The `values.state` key will always be present and describes the overall state of the component as being `pressed`, `touched`, or `default`.  In addition to `values.state`, components may optionally also have a `values.button`, `values.xAxis`, or `values.yAxis`.  Each of values are populated slightly differently based on the underlying component type.
 
-### Trigger, Grip, and Button components
-Much of the behavior of `trigger`, `grip`, and `button` components is identical, though they are often used for different interactions (e.g. grips may often be preferred for picking up objects). The `values.button` is set directly from the associated `GamepadButton.value`.  If the `GamepadButton.pressed` is true or the `GamepadButton.value` is 1, the `values.state` will be set to `pressed`.  Otherwise, if the `GamepadButton.touched` is true or the `GamepadButton.value` is greater than 0, the component's `values.state` will be set to `touched`. Otherwise the `values.state` is set to `default`. 
+### Trigger, Squeeze, and Button components
+Much of the behavior of `trigger`, `squeeze`, and `button` components is identical, though they are often used for different interactions (e.g. a squeeze may often be preferred for picking up objects). The `values.button` is set directly from the associated `GamepadButton.value`.  If the `GamepadButton.pressed` is true or the `GamepadButton.value` is 1, the `values.state` will be set to `pressed`.  Otherwise, if the `GamepadButton.touched` is true or the `GamepadButton.value` is greater than 0, the component's `values.state` will be set to `touched`. Otherwise the `values.state` is set to `default`. 
 
 ```js
 import { Constants } from './webxr-input-profiles.module.js';
@@ -113,9 +113,9 @@ function processTriggerInput(trigger) {
 ### Thumbstick and touchpad components
 Much of the behavior of `thumbstick` and `touchpad` components is identical, though they are often used for different interactions (e.g. thumbsticks may often be preferred for teleportation). These components must have either an `xAxis`, a `yAxis`, or both. The `values.xAxis` and `values.yAxis` are populated from the associated indices in the `Gamepad.axes` array.  The `value.xAxis` is `-1.0` at the far left of its range of motion and `1.0` at the far right. The `value.yAxis` is `-1.0` at the top of its range of motion and `1.0` at the bottom.  
 
-These components may also be clickable, and if so will have a `value.button` which is populated identically to those of `trigger`, `grip`, and `button` components.
+These components may also be clickable, and if so will have a `value.button` which is populated identically to those of `trigger`, `squeeze`, and `button` components.
 
-The `value.state` is set based on a combination of factors.  If clickable, `value.state` will be populated using an identical algorithm as `trigger`, `grip`, and `button` components.  If not clickable, or clickable and set to `default`, `values.state` will be set to `touched` if `values.xAxis` or `values.yAxis` are non-zero.
+The `value.state` is set based on a combination of factors.  If clickable, `value.state` will be populated using an identical algorithm as `trigger`, `squeeze`, and `button` components.  If not clickable, or clickable and set to `default`, `values.state` will be set to `touched` if `values.xAxis` or `values.yAxis` are non-zero.
 
 ```js
 import { Constants } from './webxr-input-profiles.module.js';

--- a/packages/motion-controllers/src/constants.js
+++ b/packages/motion-controllers/src/constants.js
@@ -13,7 +13,7 @@ const Constants = {
 
   ComponentType: Object.freeze({
     TRIGGER: 'trigger',
-    GRIP: 'grip',
+    SQUEEZE: 'squeeze',
     TOUCHPAD: 'touchpad',
     THUMBSTICK: 'thumbstick',
     BUTTON: 'button'

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -8,7 +8,7 @@ This package contains information for User Agents ensure they expose consistent 
 * The component responsible for causing `select`, `selectstart`, and `selectend` events to fire
 * The presence of a non-null `XRInputSource.gamepad`. When non-null:
   * The appropriate `Gamepad.mapping` value
-  * The relationship between physical hardware components (e.g. triggers, grips, buttons, touchpads, and thumbsticks) to indices in the `XRInputSource.gamepad.buttons` array.
+  * The relationship between physical hardware components (e.g. trigger, squeeze, button, touchpad, and thumbstick) to indices in the `XRInputSource.gamepad.buttons` array.
   * The relationship between physical touchpads and thumbsticks to indices in the `XRInputSource.gamepad.axes` array.
 
 ## Profile prefixes
@@ -88,7 +88,7 @@ For example:
 }
 ```
 ### Components
-Each layout is required to have a `components` property which contains information about all the individual parts of an `XRInputSource`. Components are comprised of a key which uniquely identifies them and a which describes their behavior. Component keys must not contain spaces at the beginning or end. Currently, the valid types are: `trigger`, `grip`, `touchpad`, `thumbstick`, and `button`
+Each layout is required to have a `components` property which contains information about all the individual parts of an `XRInputSource`. Components are comprised of a key which uniquely identifies them and a which describes their behavior. Component keys must not contain spaces at the beginning or end. Currently, the valid types are: `trigger`, `squeeze`, `touchpad`, `thumbstick`, and `button`
 
 Each layout is also required to have a `selectSource` property which refers to an entry in the `components` object. This component will cause the WebXR `select`, `selectStart`, and `selectEnd` events to fire.
 

--- a/packages/registry/profiles/generic/generic-trigger-squeeze-thumbstick.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze-thumbstick.json
@@ -1,19 +1,19 @@
 {
-    "profileId": "generic-trigger-grip-thumbstick",
+    "profileId": "generic-trigger-squeeze-thumbstick",
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" }
             },
             "gamepad":{
                 "mapping": "xr-standard",
                 "buttons": [ 
                     "xr-standard-trigger", 
-                    "xr-standard-grip", 
+                    "xr-standard-squeeze", 
                     null,
                     "xr-standard-thumbstick" 
                 ],

--- a/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
@@ -1,12 +1,12 @@
 {
-    "profileId": "generic-trigger-grip-touchpad-thumbstick",
+    "profileId": "generic-trigger-squeeze-touchpad-thumbstick",
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" }
             },
@@ -14,7 +14,7 @@
                 "mapping": "xr-standard",
                 "buttons": [ 
                     "xr-standard-trigger", 
-                    "xr-standard-grip", 
+                    "xr-standard-squeeze", 
                     "xr-standard-touchpad", 
                     "xr-standard-thumbstick" 
                 ],

--- a/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad.json
@@ -1,19 +1,19 @@
 {
-    "profileId": "generic-trigger-grip-touchpad",
+    "profileId": "generic-trigger-squeeze-touchpad",
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" }
             },
             "gamepad": {
                 "mapping": "xr-standard",
                 "buttons": [ 
                     "xr-standard-trigger", 
-                    "xr-standard-grip", 
+                    "xr-standard-squeeze", 
                     "xr-standard-touchpad"
                 ],
                 "axes":[

--- a/packages/registry/profiles/generic/generic-trigger-squeeze.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze.json
@@ -1,18 +1,18 @@
 {
-    "profileId" : "generic-trigger-grip",
+    "profileId" : "generic-trigger-squeeze",
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" }
+                "xr-standard-squeeze": { "type": "squeeze" }
             },
             "gamepad": {
                 "mapping": "xr-standard",
                 "buttons": [ 
                     "xr-standard-trigger",
-                    "xr-standard-grip"
+                    "xr-standard-squeeze"
                 ],
                 "axes":[]
             }

--- a/packages/registry/profiles/google/google-daydream.json
+++ b/packages/registry/profiles/google/google-daydream.json
@@ -8,8 +8,9 @@
                 "touchpad": { "type": "touchpad" }
             },
             "gamepad": {
-                "mapping": "",
+                "mapping": "xr-standard",
                 "buttons": [ 
+                    null,
                     null,
                     "touchpad"
                 ],

--- a/packages/registry/profiles/google/google-daydream.json
+++ b/packages/registry/profiles/google/google-daydream.json
@@ -8,7 +8,7 @@
                 "touchpad": { "type": "touchpad" }
             },
             "gamepad": {
-                "mapping": "xr-standard",
+                "mapping": "",
                 "buttons": [ 
                     null,
                     null,

--- a/packages/registry/profiles/htc/htc-vive.json
+++ b/packages/registry/profiles/htc/htc-vive.json
@@ -1,12 +1,12 @@
 {
     "profileId": "htc-vive",
-    "fallbackProfileIds": [ "generic-trigger-grip-touchpad"],
+    "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad"],
     "layouts" : {
         "left-right-none" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "menu" : { "type": "button" }
             },
@@ -14,7 +14,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     "xr-standard-touchpad",
                     null,
                     "menu"

--- a/packages/registry/profiles/magicleap/magicleap-one.json
+++ b/packages/registry/profiles/magicleap/magicleap-one.json
@@ -1,19 +1,19 @@
 {
     "profileId": "magicleap-one",
-    "fallbackProfileIds": ["generic-trigger-grip-touchpad"],
+    "fallbackProfileIds": ["generic-trigger-squeeze-touchpad"],
     "layouts" : {
         "none" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" }
             },
             "gamepad": {
                 "mapping": "xr-standard",
                 "buttons": [ 
                     "xr-standard-trigger", 
-                    "xr-standard-grip", 
+                    "xr-standard-squeeze", 
                     "xr-standard-touchpad"
                 ],
                 "axes":[

--- a/packages/registry/profiles/microsoft/microsoft-mixed-reality.json
+++ b/packages/registry/profiles/microsoft/microsoft-mixed-reality.json
@@ -1,12 +1,12 @@
 {
     "profileId": "microsoft-mixed-reality",
-    "fallbackProfileIds": [ "generic-trigger-grip-touchpad-thumbstick"],
+    "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad-thumbstick"],
     "layouts" : {
         "left-right" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "menu" : { "type": "button" }
@@ -15,7 +15,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     "xr-standard-touchpad",
                     "xr-standard-thumbstick",
                     "menu"

--- a/packages/registry/profiles/oculus/oculus-quest.json
+++ b/packages/registry/profiles/oculus/oculus-quest.json
@@ -1,12 +1,12 @@
 {
     "profileId": "oculus-quest",
-    "fallbackProfileIds": [ "oculus-touch", "generic-trigger-grip-thumbstick"],
+    "fallbackProfileIds": [ "oculus-touch", "generic-trigger-squeeze-thumbstick"],
     "layouts": {
         "left": {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "a-button" : { "type": "button" },
                 "b-button" : { "type": "button" }
@@ -15,7 +15,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     null,
                     "xr-standard-thumbstick",
                     "a-button",
@@ -33,7 +33,7 @@
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "x-button" : { "type": "button" },
                 "y-button" : { "type": "button" }
@@ -42,7 +42,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     null,
                     "xr-standard-thumbstick",
                     "x-button",

--- a/packages/registry/profiles/oculus/oculus-touch-s.json
+++ b/packages/registry/profiles/oculus/oculus-touch-s.json
@@ -1,12 +1,12 @@
 {
     "profileId": "oculus-touch-s",
-    "fallbackProfileIds": [ "oculus-touch", "generic-trigger-grip-thumbstick"],
+    "fallbackProfileIds": [ "oculus-touch", "generic-trigger-squeeze-thumbstick"],
     "layouts": {
         "left": {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "a-button" : { "type": "button" },
                 "b-button" : { "type": "button" }
@@ -15,7 +15,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     null,
                     "xr-standard-thumbstick",
                     "a-button",
@@ -33,7 +33,7 @@
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "x-button" : { "type": "button" },
                 "y-button" : { "type": "button" }
@@ -42,7 +42,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     null,
                     "xr-standard-thumbstick",
                     "x-button",

--- a/packages/registry/profiles/oculus/oculus-touch.json
+++ b/packages/registry/profiles/oculus/oculus-touch.json
@@ -1,12 +1,12 @@
 {
     "profileId": "oculus-touch",
-    "fallbackProfileIds": [ "generic-trigger-grip-thumbstick"],
+    "fallbackProfileIds": [ "generic-trigger-squeeze-thumbstick"],
     "layouts": {
         "left": {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "a-button" : { "type": "button" },
                 "b-button" : { "type": "button" },
@@ -16,7 +16,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     null,
                     "xr-standard-thumbstick",
                     "a-button",
@@ -35,7 +35,7 @@
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "x-button" : { "type": "button" },
                 "y-button" : { "type": "button" },
@@ -45,7 +45,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     null,
                     "xr-standard-thumbstick",
                     "x-button",

--- a/packages/registry/profiles/samsung/samsung-odyssey.json
+++ b/packages/registry/profiles/samsung/samsung-odyssey.json
@@ -1,12 +1,12 @@
 {
     "profileId": "samsung-odyssey",
-    "fallbackProfileIds": [ "microsoft-mixed-reality", "generic-trigger-grip-touchpad-thumbstick"],
+    "fallbackProfileIds": [ "microsoft-mixed-reality", "generic-trigger-squeeze-touchpad-thumbstick"],
     "layouts" : {
         "left-right" : {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "menu" : { "type": "button" }
@@ -15,7 +15,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     "xr-standard-touchpad",
                     "xr-standard-thumbstick",
                     "menu"

--- a/packages/registry/profiles/valve/valve-knuckles.json
+++ b/packages/registry/profiles/valve/valve-knuckles.json
@@ -1,12 +1,12 @@
 {
     "profileId": "valve-knuckles",
-    "fallbackProfileIds": [ "generic-trigger-grip-touchpad-thumbstick"],
+    "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad-thumbstick"],
     "layouts": {
         "left-right": {
             "selectSource": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
-                "xr-standard-grip": { "type": "grip" },
+                "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "a-button" : { "type": "button" },
@@ -16,7 +16,7 @@
                 "mapping": "xr-standard",
                 "buttons": [
                     "xr-standard-trigger",
-                    "xr-standard-grip",
+                    "xr-standard-squeeze",
                     "xr-standard-touchpad",
                     "xr-standard-thumbstick",
                     "a-button",

--- a/packages/registry/schemas/component.schema.json
+++ b/packages/registry/schemas/component.schema.json
@@ -6,7 +6,7 @@
     "properties": {
         "type": { 
             "type": "string",
-            "enum": [ "trigger", "grip", "touchpad", "thumbstick", "button"]
+            "enum": [ "trigger", "squeeze", "touchpad", "thumbstick", "button"]
         }
     },
     "required": [ "type" ]

--- a/packages/registry/src/validateRegistryProfile.js
+++ b/packages/registry/src/validateRegistryProfile.js
@@ -34,7 +34,7 @@ function validateGamepadButtonIndices({ id, components, gamepad: { buttons } }, 
     // component types as described in the WebXR Gamepads Module
     const xrStandardMapping = 'xr-standard';
     if (mapping === xrStandardMapping && index < 4) {
-      const xrStandardMappingButtonTypes = ['trigger', 'grip', 'touchpad', 'thumbstick'];
+      const xrStandardMappingButtonTypes = ['trigger', 'squeeze', 'touchpad', 'thumbstick'];
       const requiredComponentType = xrStandardMappingButtonTypes[index];
       if (component.type !== requiredComponentType) {
         throw new Error(


### PR DESCRIPTION
https://github.com/immersive-web/webxr-gamepads-module/issues/2 was decided to be fixed by renaming the term "grip" to "squeeze".  The https://github.com/immersive-web/webxr-gamepads-module/pull/14 fixes the gamepad module and this PR fixes the registry and all dependencies within this repository..