### PR TITLE
Add missing license info

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,3 @@
-TODO Figure out what licence should be here
+Unless otherwise specified in individual packages, all documents in this Repository are licensed by contributors
+under the 
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).

--- a/packages/registry/LICENSE.md
+++ b/packages/registry/LICENSE.md
@@ -1,1 +1,3 @@
-TODO Replace this with W3C contribution license
+All documents in this Repository are licensed by contributors
+under the 
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).


### PR DESCRIPTION
I'm still trying to sort out with Wendy and others what the right license/copyright text should be for the other three packages (@webxr-input-sources/assets, @webxr-input-sources/motion-controllers, and @webxr-input-sources/viewer), but in the meanwhile the rest of the repo does need the correct license/copyright applied.