### PR TITLE
Clarify naming of "source" properties

### DIFF
--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -115,14 +115,14 @@ For example
 ### Visual responses
 The visual representation of a motion controller in a VR must respond to reflect its physical state in the real-world.  For example, when a physical thumbstick is moved to the left, the virtual thumbstick should also move to the left.  The `visualResponses` array contains descriptions of all visual changes that can occur when a controller part is interacted with.
 
-Each element in this array must contain a `rootNodeName` property which references the node containing the rest of the nodes needed for the visualization. It must also contain a `source` property set to one of four values: `button`, `xAxis`, `yAxis`, or `state`.  This indicates which component property will be used to drive the visualization.  Lastly, the element must contains a `states` array which indicates the component states for which the visualization will apply.
+Each element in this array must contain a `rootNodeName` property which references the node containing the rest of the nodes needed for the visualization. It must also contain a `dataSource` property set to one of four values: `button`, `xAxis`, `yAxis`, or `state`.  This indicates which component property will be used to drive the visualization.  Lastly, the element must contains a `states` array which indicates the component states for which the visualization will apply.
 
 ```json
 {
     "visualResponses" : [
         {
             "rootNodeName": "THUMBSTICK_X",
-            "source": "xAxis",
+            "dataSource": "xAxis",
             "states": ["default", "touched", "pressed"]
         }
     ]
@@ -136,7 +136,7 @@ By default the visualization will use `"VALUE"` for the name of the target node,
     "visualResponses" : [
         {
             "rootNodeName": "THUMBSTICK_X",
-            "source": "xAxis",
+            "dataSource": "xAxis",
             "states": ["default", "touched", "pressed"],
             "targetNodeName": "TARGET"
         }
@@ -151,7 +151,7 @@ By default, all visualizations will use `"MIN"` and `"MAX"` the names of the nod
     "visualResponses" : [
         {
             "rootNodeName": "THUMBSTICK_X",
-            "source": "xAxis",
+            "dataSource": "xAxis",
             "states": ["default", "touched", "pressed"],
             "minNodeName": "LEFT",
             "maxNodeName": "RIGHT"
@@ -160,14 +160,14 @@ By default, all visualizations will use `"MIN"` and `"MAX"` the names of the nod
 }
 ```
 
-When a visualization is toggling a node's visibility, the `source` must be set to `state` and the additional `property` property set to `visibility`.
+When a visualization is toggling a node's visibility, the `dataSource` must be set to `state` and the additional `property` property set to `visibility`.
 
 ```json
 {
     "visualResponses" : [
         {
             "rootNodeName": "TOUCH_DOT",
-            "source": "state",
+            "dataSource": "state",
             "states": ["touched", "pressed"],
             "property": "visibility"
         }
@@ -182,17 +182,17 @@ Commonly, the visual responses for a thumbstick will be as follows:
     "visualResponses": [
         {
             "rootNodeName": "THUMBSTICK_PRESS",
-            "source" : "state",
+            "dataSource" : "state",
             "states" : ["pressed"]
         },
         {
             "rootNodeName": "THUMBSTICK_X",
-            "source" : "xAxis",
+            "dataSource" : "xAxis",
             "states" : ["default", "touched", "pressed"]
         },
         {
             "rootNodeName": "THUMBSTICK_Y",
-            "source" : "yAxis",
+            "dataSource" : "yAxis",
             "states" : ["default", "touched", "pressed"]
         }
     ]
@@ -206,23 +206,23 @@ Commonly, the visual responses for a touchpad will be as follows:
     "visualResponses": [
         {
             "rootNodeName": "TOUCHPAD_PRESS",
-            "source" : "state",
+            "dataSource" : "state",
             "states" : ["pressed"]
         },
         {
             "rootNodeName": "TOUCH",
-            "source" : "state",
+            "dataSource" : "state",
             "states" : ["touched", "pressed"],
             "property": "visibility"
         },
         {
             "rootNodeName": "TOUCHPAD_TOUCH_X",
-            "source" : "xAxis",
+            "dataSource" : "xAxis",
             "states" : ["default", "touched", "pressed"]
         },
         {
             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-            "source" : "yAxis",
+            "dataSource" : "yAxis",
             "states" : ["default", "touched", "pressed"]
         }
     ]
@@ -235,7 +235,7 @@ Commonly, the visual response for an analog button, such as a trigger, will be a
     "visualResponses": [
         {
             "rootNodeName" : "SELECT",
-            "source" : "button",
+            "dataSource" : "button",
             "states" : ["default", "touched", "pressed"]
         }
     ]
@@ -248,7 +248,7 @@ Alternatively, digital buttons may be better represented like this example:
     "visualResponses": [
         {
             "rootNodeName" : "MENU",
-            "source" : "state",
+            "dataSource" : "state",
             "states" : ["pressed"]
         }
     ]

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -115,14 +115,14 @@ For example
 ### Visual responses
 The visual representation of a motion controller in a VR must respond to reflect its physical state in the real-world.  For example, when a physical thumbstick is moved to the left, the virtual thumbstick should also move to the left.  The `visualResponses` array contains descriptions of all visual changes that can occur when a controller part is interacted with.
 
-Each element in this array must contain a `rootNodeName` property which references the node containing the rest of the nodes needed for the visualization. It must also contain a `dataSource` property set to one of four values: `button`, `xAxis`, `yAxis`, or `state`.  This indicates which component property will be used to drive the visualization.  Lastly, the element must contains a `states` array which indicates the component states for which the visualization will apply.
+Each element in this array must contain a `rootNodeName` property which references the node containing the rest of the nodes needed for the visualization. It must also contain a `componentProperty` property set to one of four values: `button`, `xAxis`, `yAxis`, or `state`.  This indicates which component property will be used to drive the visualization.  Lastly, the element must contains a `states` array which indicates the component states for which the visualization will apply.
 
 ```json
 {
     "visualResponses" : [
         {
             "rootNodeName": "THUMBSTICK_X",
-            "dataSource": "xAxis",
+            "componentProperty": "xAxis",
             "states": ["default", "touched", "pressed"]
         }
     ]
@@ -136,7 +136,7 @@ By default the visualization will use `"VALUE"` for the name of the target node,
     "visualResponses" : [
         {
             "rootNodeName": "THUMBSTICK_X",
-            "dataSource": "xAxis",
+            "componentProperty": "xAxis",
             "states": ["default", "touched", "pressed"],
             "targetNodeName": "TARGET"
         }
@@ -151,7 +151,7 @@ By default, all visualizations will use `"MIN"` and `"MAX"` the names of the nod
     "visualResponses" : [
         {
             "rootNodeName": "THUMBSTICK_X",
-            "dataSource": "xAxis",
+            "componentProperty": "xAxis",
             "states": ["default", "touched", "pressed"],
             "minNodeName": "LEFT",
             "maxNodeName": "RIGHT"
@@ -160,14 +160,14 @@ By default, all visualizations will use `"MIN"` and `"MAX"` the names of the nod
 }
 ```
 
-When a visualization is toggling a node's visibility, the `dataSource` must be set to `state` and the additional `property` property set to `visibility`.
+When a visualization is toggling a node's visibility, the `componentProperty` must be set to `state` and the additional `property` property set to `visibility`.
 
 ```json
 {
     "visualResponses" : [
         {
             "rootNodeName": "TOUCH_DOT",
-            "dataSource": "state",
+            "componentProperty": "state",
             "states": ["touched", "pressed"],
             "property": "visibility"
         }
@@ -182,17 +182,17 @@ Commonly, the visual responses for a thumbstick will be as follows:
     "visualResponses": [
         {
             "rootNodeName": "THUMBSTICK_PRESS",
-            "dataSource" : "state",
+            "componentProperty" : "state",
             "states" : ["pressed"]
         },
         {
             "rootNodeName": "THUMBSTICK_X",
-            "dataSource" : "xAxis",
+            "componentProperty" : "xAxis",
             "states" : ["default", "touched", "pressed"]
         },
         {
             "rootNodeName": "THUMBSTICK_Y",
-            "dataSource" : "yAxis",
+            "componentProperty" : "yAxis",
             "states" : ["default", "touched", "pressed"]
         }
     ]
@@ -206,23 +206,23 @@ Commonly, the visual responses for a touchpad will be as follows:
     "visualResponses": [
         {
             "rootNodeName": "TOUCHPAD_PRESS",
-            "dataSource" : "state",
+            "componentProperty" : "state",
             "states" : ["pressed"]
         },
         {
             "rootNodeName": "TOUCH",
-            "dataSource" : "state",
+            "componentProperty" : "state",
             "states" : ["touched", "pressed"],
             "property": "visibility"
         },
         {
             "rootNodeName": "TOUCHPAD_TOUCH_X",
-            "dataSource" : "xAxis",
+            "componentProperty" : "xAxis",
             "states" : ["default", "touched", "pressed"]
         },
         {
             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-            "dataSource" : "yAxis",
+            "componentProperty" : "yAxis",
             "states" : ["default", "touched", "pressed"]
         }
     ]
@@ -235,7 +235,7 @@ Commonly, the visual response for an analog button, such as a trigger, will be a
     "visualResponses": [
         {
             "rootNodeName" : "SELECT",
-            "dataSource" : "button",
+            "componentProperty" : "button",
             "states" : ["default", "touched", "pressed"]
         }
     ]
@@ -248,7 +248,7 @@ Alternatively, digital buttons may be better represented like this example:
     "visualResponses": [
         {
             "rootNodeName" : "MENU",
-            "dataSource" : "state",
+            "componentProperty" : "state",
             "states" : ["pressed"]
         }
     ]

--- a/packages/assets/profiles/generic/generic-button.json
+++ b/packages/assets/profiles/generic/generic-button.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-button.json
+++ b/packages/assets/profiles/generic/generic-button.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-touchpad.json
+++ b/packages/assets/profiles/generic/generic-touchpad.json
@@ -24,23 +24,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-touchpad.json
+++ b/packages/assets/profiles/generic/generic-touchpad.json
@@ -24,23 +24,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["pressed"]
                         }
                     ]
@@ -45,17 +45,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["pressed"]
                         }
                     ]
@@ -45,17 +45,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["pressed"]
                         }
                     ]
@@ -46,23 +46,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -73,17 +73,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["pressed"]
                         }
                     ]
@@ -46,23 +46,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -73,17 +73,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["pressed"]
                         }
                     ]
@@ -46,23 +46,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze-touchpad.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["pressed"]
                         }
                     ]
@@ -46,23 +46,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-squeeze.json
+++ b/packages/assets/profiles/generic/generic-trigger-squeeze.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,7 +34,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,17 +34,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -34,17 +34,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-touchpad-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-touchpad-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,23 +35,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -62,17 +62,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-touchpad-thumbstick.json
+++ b/packages/assets/profiles/generic/generic-trigger-touchpad-thumbstick.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,23 +35,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -62,17 +62,17 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-touchpad.json
+++ b/packages/assets/profiles/generic/generic-trigger-touchpad.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,23 +35,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger-touchpad.json
+++ b/packages/assets/profiles/generic/generic-trigger-touchpad.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,23 +35,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger.json
+++ b/packages/assets/profiles/generic/generic-trigger.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/generic/generic-trigger.json
+++ b/packages/assets/profiles/generic/generic-trigger.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/google/google-daydream.json
+++ b/packages/assets/profiles/google/google-daydream.json
@@ -24,23 +24,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/google/google-daydream.json
+++ b/packages/assets/profiles/google/google-daydream.json
@@ -24,23 +24,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/htc/htc-vive.json
+++ b/packages/assets/profiles/htc/htc-vive.json
@@ -24,7 +24,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,7 +35,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -47,23 +47,23 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -74,7 +74,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/htc/htc-vive.json
+++ b/packages/assets/profiles/htc/htc-vive.json
@@ -24,7 +24,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,7 +35,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -47,23 +47,23 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -74,7 +74,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/microsoft/microsoft-mixed-reality.json
+++ b/packages/assets/profiles/microsoft/microsoft-mixed-reality.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -47,25 +47,25 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -76,19 +76,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -99,7 +99,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"

--- a/packages/assets/profiles/microsoft/microsoft-mixed-reality.json
+++ b/packages/assets/profiles/microsoft/microsoft-mixed-reality.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -47,25 +47,25 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -76,19 +76,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -99,7 +99,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"

--- a/packages/assets/profiles/oculus/oculus-go.json
+++ b/packages/assets/profiles/oculus/oculus-go.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,23 +35,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/oculus/oculus-go.json
+++ b/packages/assets/profiles/oculus/oculus-go.json
@@ -23,7 +23,7 @@
                     "visualResponses" : [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -35,23 +35,23 @@
                     "visualResponses" : [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]

--- a/packages/assets/profiles/oculus/oculus-quest.json
+++ b/packages/assets/profiles/oculus/oculus-quest.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -46,19 +46,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -69,7 +69,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -80,7 +80,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -96,7 +96,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -109,7 +109,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -122,19 +122,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -145,7 +145,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "X-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -156,7 +156,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "Y-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/oculus/oculus-quest.json
+++ b/packages/assets/profiles/oculus/oculus-quest.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -46,19 +46,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -69,7 +69,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -80,7 +80,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -96,7 +96,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -109,7 +109,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -122,19 +122,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -145,7 +145,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "X-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -156,7 +156,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "Y-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/oculus/oculus-touch-s.json
+++ b/packages/assets/profiles/oculus/oculus-touch-s.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -46,19 +46,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -69,7 +69,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -80,7 +80,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -96,7 +96,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -109,7 +109,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -122,19 +122,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -145,7 +145,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "X-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -156,7 +156,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "Y-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/oculus/oculus-touch-s.json
+++ b/packages/assets/profiles/oculus/oculus-touch-s.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -46,19 +46,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -69,7 +69,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -80,7 +80,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -96,7 +96,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -109,7 +109,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -122,19 +122,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -145,7 +145,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "X-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -156,7 +156,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "Y-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/oculus/oculus-touch.json
+++ b/packages/assets/profiles/oculus/oculus-touch.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -46,19 +46,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -69,7 +69,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -80,7 +80,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -91,7 +91,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "THUMBREST",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property" : "visibility"
                         }
@@ -108,7 +108,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -121,7 +121,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -134,19 +134,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -157,7 +157,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "X-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -168,7 +168,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "Y-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -179,7 +179,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "THUMBREST",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property" : "visibility"
                         }

--- a/packages/assets/profiles/oculus/oculus-touch.json
+++ b/packages/assets/profiles/oculus/oculus-touch.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -46,19 +46,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -69,7 +69,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -80,7 +80,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -91,7 +91,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "THUMBREST",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property" : "visibility"
                         }
@@ -108,7 +108,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -121,7 +121,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -134,19 +134,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -157,7 +157,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "X-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -168,7 +168,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "Y-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -179,7 +179,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "THUMBREST",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property" : "visibility"
                         }

--- a/packages/assets/profiles/samsung/samsung-gearvr.json
+++ b/packages/assets/profiles/samsung/samsung-gearvr.json
@@ -16,7 +16,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -28,23 +28,23 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -55,7 +55,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/samsung/samsung-gearvr.json
+++ b/packages/assets/profiles/samsung/samsung-gearvr.json
@@ -16,7 +16,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -28,23 +28,23 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -55,7 +55,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/samsung/samsung-odyssey.json
+++ b/packages/assets/profiles/samsung/samsung-odyssey.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -47,25 +47,25 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -76,19 +76,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -99,7 +99,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"

--- a/packages/assets/profiles/samsung/samsung-odyssey.json
+++ b/packages/assets/profiles/samsung/samsung-odyssey.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -47,25 +47,25 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -76,19 +76,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -99,7 +99,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "MENU",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"

--- a/packages/assets/profiles/valve/valve-index.json
+++ b/packages/assets/profiles/valve/valve-index.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "source" : "button",
+                            "dataSource" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -47,23 +47,23 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -74,19 +74,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "source" : "xAxis",
+                            "dataSource" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "source" : "yAxis",
+                            "dataSource" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -97,7 +97,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -108,7 +108,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "source" : "state",
+                            "dataSource" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/profiles/valve/valve-index.json
+++ b/packages/assets/profiles/valve/valve-index.json
@@ -20,7 +20,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "SELECT",
-                            "dataSource" : "button",
+                            "componentProperty" : "button",
                             "states" : ["default", "touched", "pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -33,7 +33,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "GRASP",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
@@ -47,23 +47,23 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "TOUCHPAD_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         },
                         {
                             "rootNodeName": "TOUCH",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["touched", "pressed"],
                             "property": "visibility"
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "TOUCHPAD_TOUCH_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -74,19 +74,19 @@
                     "visualResponses": [
                         {
                             "rootNodeName": "THUMBSTICK_PRESS",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"],
                             "minNodeName": "UNPRESSED",
                             "maxNodeName": "PRESSED"
                         },
                         {
                             "rootNodeName": "THUMBSTICK_X",
-                            "dataSource" : "xAxis",
+                            "componentProperty" : "xAxis",
                             "states" : ["default", "touched", "pressed"]
                         },
                         {
                             "rootNodeName": "THUMBSTICK_Y",
-                            "dataSource" : "yAxis",
+                            "componentProperty" : "yAxis",
                             "states" : ["default", "touched", "pressed"]
                         }
                     ]
@@ -97,7 +97,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "A-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]
@@ -108,7 +108,7 @@
                     "visualResponses": [
                         {
                             "rootNodeName" : "B-BUTTON",
-                            "dataSource" : "state",
+                            "componentProperty" : "state",
                             "states" : ["pressed"]
                         }
                     ]

--- a/packages/assets/schemas/visualResponses.schema.json
+++ b/packages/assets/schemas/visualResponses.schema.json
@@ -8,14 +8,14 @@
     "uniqueItems": true,
     "items": {
         "type": "object",
-        "required": ["rootNodeName", "source", "states"],
+        "required": ["rootNodeName", "dataSource", "states"],
         "additionalProperties": false,
         "properties": {
             "rootNodeName" : {
                 "description": "The node in the asset containing the nodes of this visualization",
                 "type": "string"
             },
-            "source": {
+            "dataSource": {
                 "description": "The property name driving this visualization",
                 "type": "string",
                 "enum": ["xAxis", "yAxis", "button", "state"]
@@ -48,7 +48,7 @@
         },
         "if": {
             "properties": {
-                "source": { "enum":["state"] }
+                "dataSource": { "enum":["state"] }
             }
         },
         "then": {

--- a/packages/assets/schemas/visualResponses.schema.json
+++ b/packages/assets/schemas/visualResponses.schema.json
@@ -8,14 +8,14 @@
     "uniqueItems": true,
     "items": {
         "type": "object",
-        "required": ["rootNodeName", "dataSource", "states"],
+        "required": ["rootNodeName", "componentProperty", "states"],
         "additionalProperties": false,
         "properties": {
             "rootNodeName" : {
                 "description": "The node in the asset containing the nodes of this visualization",
                 "type": "string"
             },
-            "dataSource": {
+            "componentProperty": {
                 "description": "The property name driving this visualization",
                 "type": "string",
                 "enum": ["xAxis", "yAxis", "button", "state"]
@@ -48,7 +48,7 @@
         },
         "if": {
             "properties": {
-                "dataSource": { "enum":["state"] }
+                "componentProperty": { "enum":["state"] }
             }
         },
         "then": {

--- a/packages/motion-controllers/src/__tests__/visualResponse.test.js
+++ b/packages/motion-controllers/src/__tests__/visualResponse.test.js
@@ -20,10 +20,10 @@ describe('Construction tests', () => {
   });
   test.each([
     ['button', 'state', 'xAxis', 'yAxis']
-  ])('Create with %s dataSource and no additional properties', (dataSource) => {
+  ])('Create with %s componentProperty and no additional properties', (componentProperty) => {
     const responseDescription = {
       rootNodeName: 'ROOT',
-      dataSource,
+      componentProperty,
       states: [Constants.ComponentState.DEFAULT]
     };
 
@@ -42,7 +42,7 @@ describe('Construction tests', () => {
   test('Create with explicit properties', () => {
     const responseDescription = {
       rootNodeName: 'ROOT',
-      dataSource: 'button',
+      componentProperty: 'button',
       states: [Constants.ComponentState.DEFAULT],
       targetNodeName: 'TARGET',
       minNodeName: 'MY MIN NODE',
@@ -64,7 +64,7 @@ describe('Weighting tests', () => {
     };
 
     const responseDescription = {
-      dataSource: 'button',
+      componentProperty: 'button',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
@@ -87,13 +87,13 @@ describe('Weighting tests', () => {
     };
 
     const xAxisResponseDescription = {
-      dataSource: 'xAxis',
+      componentProperty: 'xAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
 
     const yAxisResponseDescription = {
-      dataSource: 'yAxis',
+      componentProperty: 'yAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
@@ -133,13 +133,13 @@ describe('Weighting tests', () => {
     };
 
     const xAxisResponseDescription = {
-      dataSource: 'xAxis',
+      componentProperty: 'xAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
 
     const yAxisResponseDescription = {
-      dataSource: 'yAxis',
+      componentProperty: 'yAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
@@ -161,7 +161,7 @@ describe('Weighting tests', () => {
     };
 
     const responseDescription = {
-      dataSource: 'state',
+      componentProperty: 'state',
       states: [Constants.ComponentState.DEFAULT],
       property: 'visibility'
     };
@@ -181,7 +181,7 @@ describe('Weighting tests', () => {
     };
 
     const responseDescription = {
-      dataSource: 'state',
+      componentProperty: 'state',
       states: [Constants.ComponentState.DEFAULT]
     };
 

--- a/packages/motion-controllers/src/__tests__/visualResponse.test.js
+++ b/packages/motion-controllers/src/__tests__/visualResponse.test.js
@@ -20,10 +20,10 @@ describe('Construction tests', () => {
   });
   test.each([
     ['button', 'state', 'xAxis', 'yAxis']
-  ])('Create with %s source and no additional properties', (source) => {
+  ])('Create with %s dataSource and no additional properties', (dataSource) => {
     const responseDescription = {
       rootNodeName: 'ROOT',
-      source,
+      dataSource,
       states: [Constants.ComponentState.DEFAULT]
     };
 
@@ -42,7 +42,7 @@ describe('Construction tests', () => {
   test('Create with explicit properties', () => {
     const responseDescription = {
       rootNodeName: 'ROOT',
-      source: 'button',
+      dataSource: 'button',
       states: [Constants.ComponentState.DEFAULT],
       targetNodeName: 'TARGET',
       minNodeName: 'MY MIN NODE',
@@ -64,7 +64,7 @@ describe('Weighting tests', () => {
     };
 
     const responseDescription = {
-      source: 'button',
+      dataSource: 'button',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
@@ -87,13 +87,13 @@ describe('Weighting tests', () => {
     };
 
     const xAxisResponseDescription = {
-      source: 'xAxis',
+      dataSource: 'xAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
 
     const yAxisResponseDescription = {
-      source: 'yAxis',
+      dataSource: 'yAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
@@ -133,13 +133,13 @@ describe('Weighting tests', () => {
     };
 
     const xAxisResponseDescription = {
-      source: 'xAxis',
+      dataSource: 'xAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
 
     const yAxisResponseDescription = {
-      source: 'yAxis',
+      dataSource: 'yAxis',
       states: [Constants.ComponentState.DEFAULT],
       property: 'transform'
     };
@@ -161,7 +161,7 @@ describe('Weighting tests', () => {
     };
 
     const responseDescription = {
-      source: 'state',
+      dataSource: 'state',
       states: [Constants.ComponentState.DEFAULT],
       property: 'visibility'
     };
@@ -181,7 +181,7 @@ describe('Weighting tests', () => {
     };
 
     const responseDescription = {
-      source: 'state',
+      dataSource: 'state',
       states: [Constants.ComponentState.DEFAULT]
     };
 

--- a/packages/motion-controllers/src/visualResponse.js
+++ b/packages/motion-controllers/src/visualResponse.js
@@ -83,7 +83,7 @@ class VisualResponse {
     xAxis, yAxis, button, state
   }) {
     const { normalizedXAxis, normalizedYAxis } = normalizeAxes(xAxis, yAxis);
-    switch (this.description.dataSource) {
+    switch (this.description.componentProperty) {
       case 'xAxis':
         this.value = (this.description.states.includes(state)) ? normalizedXAxis : 0.5;
         break;

--- a/packages/motion-controllers/src/visualResponse.js
+++ b/packages/motion-controllers/src/visualResponse.js
@@ -83,7 +83,7 @@ class VisualResponse {
     xAxis, yAxis, button, state
   }) {
     const { normalizedXAxis, normalizedYAxis } = normalizeAxes(xAxis, yAxis);
-    switch (this.description.source) {
+    switch (this.description.dataSource) {
       case 'xAxis':
         this.value = (this.description.states.includes(state)) ? normalizedXAxis : 0.5;
         break;

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -108,7 +108,7 @@ For example:
 ### Gamepads
 If an `XRInputSource` will have a non-null `XRInputSource.gamepad`, the profile must contain information which allows all User Agents to report identical data in `Gamepad.mapping`, `Gamepad.buttons`, and `Gamepad.axes`.  These details are enumerated in the layout's `gamepad` property.
 
-The `gamepad.mapping` string must follow the rules laid out in the [WebXR Gamepads Module](https://www.w3.org/tr/webxr-gamepads-module). The `gamepad.buttons` propety is an array which matches index-for-index with the web platform's `Gamepad.buttons` array. Each index contains either null or the id of the component from which the data must be populated. The `gamepad.axes` property is an array which matches index-for-index with the web platform's `Gamepad.axes` array. Each index contains either null or the combination of component id and axis from which the data must be populated.
+The `gamepad.mapping` string must follow the rules laid out in the [WebXR Gamepads Module](https://www.w3.org/tr/webxr-gamepads-module). The `gamepad.buttons` property is an array which matches index-for-index with the web platform's `Gamepad.buttons` array. Each index contains either null or the id of the component from which the data must be populated. The `gamepad.axes` property is an array which matches index-for-index with the web platform's `Gamepad.axes` array. Each index contains either null or the combination of component id and axis from which the data must be populated.
 
 For example:
 ```json

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -88,14 +88,14 @@ For example:
 ### Components
 Each layout is required to have a `components` property which contains information about all the individual parts of an `XRInputSource`. Components are comprised of a key which uniquely identifies them and a which describes their behavior. Component keys must not contain spaces at the beginning or end. Currently, the valid types are: `trigger`, `squeeze`, `touchpad`, `thumbstick`, and `button`
 
-Each layout is also required to have a `selectSource` property which refers to an entry in the `components` object. This component will cause the WebXR `select`, `selectStart`, and `selectEnd` events to fire.
+Each layout is also required to have a `selectComponentId` property which refers to an entry in the `components` object. This component will cause the WebXR `select`, `selectStart`, and `selectEnd` events to fire.
 
 For example:
 ```json
 {
     "layouts": {
         "left-right": {
-            "selectSource": "my-hardware-trigger-name",
+            "selectComponentId": "my-hardware-trigger-name",
             "components": {
                 "my-hardware-trigger-name": { "type": "trigger" },
                 "my-hardware-touchpad-name": { "type": "touchpad" }

--- a/packages/registry/profiles/generic/generic-button.json
+++ b/packages/registry/profiles/generic/generic-button.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "faceButton",
+            "selectComponentId": "faceButton",
             "components": {
                 "faceButton": { "type": "button" }
             },

--- a/packages/registry/profiles/generic/generic-touchpad.json
+++ b/packages/registry/profiles/generic/generic-touchpad.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "touchpad",
+            "selectComponentId": "touchpad",
             "components": {
                 "touchpad": { "type": "touchpad" }
             },

--- a/packages/registry/profiles/generic/generic-trigger-squeeze-thumbstick.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze-thumbstick.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad-thumbstick.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze-touchpad.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/generic/generic-trigger-squeeze.json
+++ b/packages/registry/profiles/generic/generic-trigger-squeeze.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" }

--- a/packages/registry/profiles/generic/generic-trigger-thumbstick.json
+++ b/packages/registry/profiles/generic/generic-trigger-thumbstick.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-thumbstick": { "type": "thumbstick" }

--- a/packages/registry/profiles/generic/generic-trigger-touchpad-thumbstick.json
+++ b/packages/registry/profiles/generic/generic-trigger-touchpad-thumbstick.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-touchpad": { "type": "touchpad" },

--- a/packages/registry/profiles/generic/generic-trigger-touchpad.json
+++ b/packages/registry/profiles/generic/generic-trigger-touchpad.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-touchpad": { "type": "touchpad" }

--- a/packages/registry/profiles/generic/generic-trigger.json
+++ b/packages/registry/profiles/generic/generic-trigger.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" }
             },

--- a/packages/registry/profiles/google/google-daydream.json
+++ b/packages/registry/profiles/google/google-daydream.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": ["generic-touchpad"],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "touchpad",
+            "selectComponentId": "touchpad",
             "components": {
                 "touchpad": { "type": "touchpad" }
             },

--- a/packages/registry/profiles/htc/htc-vive.json
+++ b/packages/registry/profiles/htc/htc-vive.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad"],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/magicleap/magicleap-one.json
+++ b/packages/registry/profiles/magicleap/magicleap-one.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": ["generic-trigger-squeeze-touchpad"],
     "layouts" : {
         "none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/microsoft/microsoft-mixed-reality.json
+++ b/packages/registry/profiles/microsoft/microsoft-mixed-reality.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad-thumbstick"],
     "layouts" : {
         "left-right" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/oculus/oculus-go.json
+++ b/packages/registry/profiles/oculus/oculus-go.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "generic-trigger-touchpad"],
     "layouts": {
         "left-right-none": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-touchpad": { "type": "touchpad" }

--- a/packages/registry/profiles/oculus/oculus-quest.json
+++ b/packages/registry/profiles/oculus/oculus-quest.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "oculus-touch", "generic-trigger-squeeze-thumbstick"],
     "layouts": {
         "left": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },
@@ -30,7 +30,7 @@
             }
         },
         "right": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/oculus/oculus-touch-s.json
+++ b/packages/registry/profiles/oculus/oculus-touch-s.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "oculus-touch", "generic-trigger-squeeze-thumbstick"],
     "layouts": {
         "left": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },
@@ -30,7 +30,7 @@
             }
         },
         "right": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/oculus/oculus-touch.json
+++ b/packages/registry/profiles/oculus/oculus-touch.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "generic-trigger-squeeze-thumbstick"],
     "layouts": {
         "left": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },
@@ -32,7 +32,7 @@
             }
         },
         "right": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/samsung/samsung-gearvr.json
+++ b/packages/registry/profiles/samsung/samsung-gearvr.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "generic-trigger-touchpad"],
     "layouts" : {
         "left-right-none" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-touchpad": { "type": "touchpad" },

--- a/packages/registry/profiles/samsung/samsung-odyssey.json
+++ b/packages/registry/profiles/samsung/samsung-odyssey.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "microsoft-mixed-reality", "generic-trigger-squeeze-touchpad-thumbstick"],
     "layouts" : {
         "left-right" : {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/profiles/valve/valve-index.json
+++ b/packages/registry/profiles/valve/valve-index.json
@@ -3,7 +3,7 @@
     "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad-thumbstick"],
     "layouts": {
         "left-right": {
-            "selectSource": "xr-standard-trigger",
+            "selectComponentId": "xr-standard-trigger",
             "components": {
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },

--- a/packages/registry/schemas/layout.schema.json
+++ b/packages/registry/schemas/layout.schema.json
@@ -4,9 +4,9 @@
     "type": "object",
     "description": "A layout",
     "additionalProperties": false,
-    "required": [ "components", "selectSource" ],
+    "required": [ "components", "selectComponentId" ],
     "properties": {
-        "selectSource": { "$ref": "common.schema.json#/definitions/componentId" },
+        "selectComponentId": { "$ref": "common.schema.json#/definitions/componentId" },
         "components": { "$ref": "common.schema.json#/definitions/components" },
         "gamepad": {
             "type": "object",

--- a/packages/registry/src/validateRegistryProfile.js
+++ b/packages/registry/src/validateRegistryProfile.js
@@ -129,8 +129,8 @@ function validate(profileJson, profilesListJson) {
       const layout = profileJson.layouts[layoutId];
 
       // Validate select source points to a valid component
-      if (!layout.components[layout.selectSource]) {
-        throw new Error(`selectionSource ${layout.selectSource} is not a known component`);
+      if (!layout.components[layout.selectComponentId]) {
+        throw new Error(`selectComponentId ${layout.selectComponentId} does not match a known component`);
       }
 
       // Validate gamepad arrays match components


### PR DESCRIPTION
This PR attempts to address the naming concerns raised in #86 

Registry property "selectSource" is now "selectComponentId" and VisualResponse property "source" is now "dataSource".  Happy to use different names if folks still think these changes are unclear.

/fixes #86