### PR TITLE
Define and enforce fallbackProfileIds rules

### DIFF
--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -55,7 +55,7 @@ Fill in the steps for filing a pull request https://github.com/immersive-web/web
 ## Schema
 
 ### Profile id and fallback profile ids
-Profiles are required to have a `profileId` that uniquely identifies the profile and must conform to the format specified by the [WebXR Device API](http://www.w3.org/tr/webxr). A `profileId` cannot be changed once added to the registry; if changes are necessary a new `profileId` must be defined. Profiles are also required to have a `fallbackProfileIds` array containing profile ids defined in the registry that are considered acceptable fallback substitutes for profile. Profiles with the `generic` prefix may have this array empty.  All other profiles must have at least one fallback profile id, and the the last entry in the array must have the `generic` vendor prefix. 
+Profiles are required to have a `profileId` that uniquely identifies the profile and must conform to the format specified by the [WebXR Device API](http://www.w3.org/tr/webxr). A `profileId` cannot be changed once added to the registry; if changes are necessary a new `profileId` must be defined.Profiles are also required to have a `fallbackProfileIds` array containing profile ids defined in the registry that are considered acceptable fallback substitutes for profile. The contents of this array may be modified after the profile has been added to the repository, however changes should be avoided if at all possible due to the potential for conformance mismatches.  Profiles with the `generic` prefix may leave the `fallbackProfileIds` array empty.  All other profiles must have at least one fallback profile id, and the the last entry in the array must have the `generic` vendor prefix. 
 
 For example
 ```json

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -55,13 +55,13 @@ Fill in the steps for filing a pull request https://github.com/immersive-web/web
 ## Schema
 
 ### Profile id and fallback profile ids
-Profiles are required to have a `profileId` that uniquely identifies the profile and must conform to the format specified by the [WebXR Device API](http://www.w3.org/tr/webxr). Profiles are also required to have a `fallbackProfileIds` array containing profile ids that are considered acceptable substitutes for profile. This array may be empty, but, if it is not, the ids it contains must match another existing profile detailed in this repository. 
+Profiles are required to have a `profileId` that uniquely identifies the profile and must conform to the format specified by the [WebXR Device API](http://www.w3.org/tr/webxr). A `profileId` cannot be changed once added to the registry; if changes are necessary a new `profileId` must be defined. Profiles are also required to have a `fallbackProfileIds` array containing profile ids defined in the registry that are considered acceptable fallback substitutes for profile. Profiles with the `generic` prefix may have this array empty.  All other profiles must have at least one fallback profile id, and the the last entry in the array must have the `generic` vendor prefix. 
 
 For example
 ```json
 {
     "profileId" : "vendorprefix-profileId",
-    "fallbackProfileIds" : ["vendorprefix-otherProfileId", "generic-thumbstick"]
+    "fallbackProfileIds" : ["vendorprefix-otherProfileId", "generic-trigger"]
 }
 ```
 

--- a/packages/registry/src/validateRegistryProfile.js
+++ b/packages/registry/src/validateRegistryProfile.js
@@ -138,16 +138,22 @@ function validate(profileJson, profilesListJson) {
       validateGamepadAxesIndices(layout, profileJson.mapping);
     });
 
+    const fallbackIds = profileJson.fallbackProfileIds;
     if (profilesListJson) {
       // Validate fallbackProfiles are real
-      profileJson.fallbackProfileIds.forEach((profileId) => {
+      fallbackIds.forEach((profileId) => {
         if (!profilesListJson[profileId]) {
           throw new Error(`Fallback profile ${profileId} does not exist`);
         }
       });
     }
 
-    // TODO validate the fallback profiles match the layout
+    if (!profileJson.profileId.startsWith('generic-')) {
+      const lastFallbackId = fallbackIds[fallbackIds.length - 1];
+      if (!lastFallbackId.startsWith('generic-')) {
+        throw new Error('Final fallback profile id must be for a generic profile');
+      }
+    }
   } catch (error) {
     error.message = `${profileJson.profileId} - ${error.message}`;
     throw error;


### PR DESCRIPTION
/fixes #99 

Clarifies the README.md text to match the rules in #99 and adds a check in the validation step to ensure that the last fallback is a generic.