### PR TITLE
Adding a dummy thumbrest to oculus-touch-v2 

### DIFF
--- a/packages/assets/profiles/oculus/oculus-touch-v2.json
+++ b/packages/assets/profiles/oculus/oculus-touch-v2.json
@@ -84,6 +84,11 @@
                             "states" : ["pressed"]
                         }
                     ]
+                },
+                "thumbrest": {
+                    "rootNodeName" : "THUMBREST",
+                    "labelAnchorNodeName" : "THUMBREST-label",
+                    "visualResponses": []
                 }
             }
         },
@@ -160,6 +165,11 @@
                             "states" : ["pressed"]
                         }
                     ]
+                },
+                "thumbrest": {
+                    "rootNodeName" : "THUMBREST",
+                    "labelAnchorNodeName" : "THUMBREST-label",
+                    "visualResponses": []
                 }
             }
         }

--- a/packages/assets/schemas/visualResponses.schema.json
+++ b/packages/assets/schemas/visualResponses.schema.json
@@ -3,7 +3,7 @@
     "$id": "https://immersive-web/webxr-input-profiles/assets/0.1.0/visualResponses.schema.json",
     "type": "array",
     "description": "The responses array",
-    "minItems": 1,
+    "minItems": 0,
     "additionalItems": false,
     "uniqueItems": true,
     "items": {

--- a/packages/registry/profiles/oculus/oculus-touch-v2.json
+++ b/packages/registry/profiles/oculus/oculus-touch-v2.json
@@ -9,7 +9,8 @@
                 "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "a-button" : { "type": "button" },
-                "b-button" : { "type": "button" }
+                "b-button" : { "type": "button" },
+                "thumbrest" : { "type": "button" }
             },
             "gamepad": {
                 "mapping": "xr-standard",
@@ -19,7 +20,8 @@
                     null,
                     "xr-standard-thumbstick",
                     "a-button",
-                    "b-button"
+                    "b-button",
+                    "thumbrest"
                 ],
                 "axes":[
                     null,
@@ -36,7 +38,8 @@
                 "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "x-button" : { "type": "button" },
-                "y-button" : { "type": "button" }
+                "y-button" : { "type": "button" },
+                "thumbrest" : { "type": "button" }
             },
             "gamepad": {
                 "mapping": "xr-standard",
@@ -46,7 +49,8 @@
                     null,
                     "xr-standard-thumbstick",
                     "x-button",
-                    "y-button"
+                    "y-button",
+                    "thumbrest"
                 ],
                 "axes":[
                     null,


### PR DESCRIPTION
Adding a dummy thumbrest to oculus-touch-v2 (Rift S / Quest) for backward compatibility with oculus-touch (Rift).