### PR TITLE
Fix missing axes in viewer

### DIFF
--- a/packages/assets/src/buildAssetProfile.js
+++ b/packages/assets/src/buildAssetProfile.js
@@ -5,22 +5,22 @@ const STANDARD_VISUAL_RESPONSES = {
     valueNodeProperty: 'transform'
   },
   xaxis_pressed: {
-    componentProperty: 'x_axis',
+    componentProperty: 'xAxis',
     states: ['default', 'touched', 'pressed'],
     valueNodeProperty: 'transform'
   },
   yaxis_pressed: {
-    componentProperty: 'y_axis',
+    componentProperty: 'yAxis',
     states: ['default', 'touched', 'pressed'],
     valueNodeProperty: 'transform'
   },
   xaxis_touched: {
-    componentProperty: 'x_axis',
+    componentProperty: 'xAxis',
     states: ['default', 'touched', 'pressed'],
     valueNodeProperty: 'transform'
   },
   yaxis_touched: {
-    componentProperty: 'y_axis',
+    componentProperty: 'yAxis',
     states: ['default', 'touched', 'pressed'],
     valueNodeProperty: 'transform'
   },

--- a/packages/assets/src/expandRegistryProfile.js
+++ b/packages/assets/src/expandRegistryProfile.js
@@ -35,7 +35,13 @@ function expandRegistryProfile(registryProfile) {
           // Add axes indices to component
           layoutInfo.gamepad.axes.forEach((axisInfo, index) => {
             if (axisInfo !== null && axisInfo.componentId === componentId) {
-              component.gamepadIndices[axisInfo.axis] = index;
+              const axisIndexName = {
+                'x-axis': 'xAxis',
+                'y-axis': 'yAxis',
+                'z-axis': 'zAxis'
+              }[axisInfo.axis];
+
+              component.gamepadIndices[axisIndexName] = index;
             }
           });
 

--- a/packages/motion-controllers/src/components.js
+++ b/packages/motion-controllers/src/components.js
@@ -16,44 +16,26 @@ class Component {
     }
 
     this.id = componentId;
-    this.description = componentDescription;
+    this.type = componentDescription.type;
+    this.rootNodeName = componentDescription.rootNodeName;
+    this.touchPointNodeName = componentDescription.touchPointNodeName;
 
     // Build all the visual responses for this component
     this.visualResponses = {};
-    Object.keys(this.description.visualResponses).forEach((responseName) => {
-      const visualResponse = new VisualResponse(this.description.visualResponses[responseName]);
+    Object.keys(componentDescription.visualResponses).forEach((responseName) => {
+      const visualResponse = new VisualResponse(componentDescription.visualResponses[responseName]);
       this.visualResponses[responseName] = visualResponse;
     });
 
     // Set default values
-    const {
-      [Constants.ComponentProperty.BUTTON]: buttonIndex,
-      [Constants.ComponentProperty.X_AXIS]: xAxisIndex,
-      [Constants.ComponentProperty.Y_AXIS]: yAxisIndex
-    } = this.description.gamepadIndices;
+    this.gamepadIndices = Object.assign({}, componentDescription.gamepadIndices);
 
     this.values = {
       state: Constants.ComponentState.DEFAULT,
-      button: (buttonIndex !== undefined) ? 0 : undefined,
-      xAxis: (xAxisIndex !== undefined) ? 0 : undefined,
-      yAxis: (yAxisIndex !== undefined) ? 0 : undefined
+      button: (this.gamepadIndices.button !== undefined) ? 0 : undefined,
+      xAxis: (this.gamepadIndices.xAxis !== undefined) ? 0 : undefined,
+      yAxis: (this.gamepadIndices.yAxis !== undefined) ? 0 : undefined
     };
-  }
-
-  get type() {
-    return this.description.type;
-  }
-
-  get rootNodeName() {
-    return this.description.rootNodeName;
-  }
-
-  get labelAnchorNodeName() {
-    return this.description.labelAnchorNodeName;
-  }
-
-  get touchPointNodeName() {
-    return this.description.touchPointNodeName;
   }
 
   get data() {
@@ -66,18 +48,12 @@ class Component {
    * @param {Object} gamepad - The gamepad object from which the component data should be polled
    */
   updateFromGamepad(gamepad) {
-    const {
-      [Constants.ComponentProperty.BUTTON]: buttonIndex,
-      [Constants.ComponentProperty.X_AXIS]: xAxisIndex,
-      [Constants.ComponentProperty.Y_AXIS]: yAxisIndex
-    } = this.description.gamepadIndices;
-
     // Set the state to default before processing other data sources
     this.values.state = Constants.ComponentState.DEFAULT;
 
     // Get and normalize button
-    if (buttonIndex !== undefined) {
-      const gamepadButton = gamepad.buttons[buttonIndex];
+    if (this.gamepadIndices.button !== undefined) {
+      const gamepadButton = gamepad.buttons[this.gamepadIndices.button];
       this.values.button = gamepadButton.value;
       this.values.button = (this.values.button < 0) ? 0 : this.values.button;
       this.values.button = (this.values.button > 1) ? 1 : this.values.button;
@@ -91,8 +67,8 @@ class Component {
     }
 
     // Get and normalize x axis value
-    if (xAxisIndex !== undefined) {
-      this.values.xAxis = gamepad.axes[xAxisIndex];
+    if (this.gamepadIndices.xAxis !== undefined) {
+      this.values.xAxis = gamepad.axes[this.gamepadIndices.xAxis];
       this.values.xAxis = (this.values.xAxis < -1) ? -1 : this.values.xAxis;
       this.values.xAxis = (this.values.xAxis > 1) ? 1 : this.values.xAxis;
 
@@ -104,8 +80,8 @@ class Component {
     }
 
     // Get and normalize Y axis value
-    if (yAxisIndex !== undefined) {
-      this.values.yAxis = gamepad.axes[yAxisIndex];
+    if (this.gamepadIndices.yAxis !== undefined) {
+      this.values.yAxis = gamepad.axes[this.gamepadIndices.yAxis];
       this.values.yAxis = (this.values.yAxis < -1) ? -1 : this.values.yAxis;
       this.values.yAxis = (this.values.yAxis > 1) ? 1 : this.values.yAxis;
 

--- a/packages/motion-controllers/src/constants.js
+++ b/packages/motion-controllers/src/constants.js
@@ -13,8 +13,8 @@ const Constants = {
 
   ComponentProperty: Object.freeze({
     BUTTON: 'button',
-    X_AXIS: 'x_axis',
-    Y_AXIS: 'y_axis',
+    X_AXIS: 'xAxis',
+    Y_AXIS: 'yAxis',
     STATE: 'state'
   }),
 

--- a/packages/viewer/src/manualControls.js
+++ b/packages/viewer/src/manualControls.js
@@ -1,7 +1,3 @@
-/* eslint-disable import/no-unresolved */
-import { Constants } from './motion-controllers.module.js';
-/* eslint-enable */
-
 let motionController;
 let mockGamepad;
 let controlsListElement;
@@ -72,12 +68,6 @@ function build(sourceMotionController) {
   mockGamepad = motionController.xrInputSource.gamepad;
 
   Object.values(motionController.components).forEach((component) => {
-    const {
-      [Constants.ComponentProperty.BUTTON]: buttonIndex,
-      [Constants.ComponentProperty.X_AXIS]: xAxisIndex,
-      [Constants.ComponentProperty.Y_AXIS]: yAxisIndex
-    } = component.description.gamepadIndices;
-
     const componentControlsElement = document.createElement('li');
     componentControlsElement.setAttribute('class', 'component');
     controlsListElement.appendChild(componentControlsElement);
@@ -86,16 +76,16 @@ function build(sourceMotionController) {
     headingElement.innerText = `${component.id}`;
     componentControlsElement.appendChild(headingElement);
 
-    if (buttonIndex !== undefined) {
-      addButtonControls(componentControlsElement, buttonIndex);
+    if (component.gamepadIndices.button !== undefined) {
+      addButtonControls(componentControlsElement, component.gamepadIndices.button);
     }
 
-    if (xAxisIndex !== undefined) {
-      addAxisControls(componentControlsElement, 'xAxis', xAxisIndex);
+    if (component.gamepadIndices.xAxis !== undefined) {
+      addAxisControls(componentControlsElement, 'xAxis', component.gamepadIndices.xAxis);
     }
 
-    if (yAxisIndex !== undefined) {
-      addAxisControls(componentControlsElement, 'yAxis', yAxisIndex);
+    if (component.gamepadIndices.yAxis !== undefined) {
+      addAxisControls(componentControlsElement, 'yAxis', component.gamepadIndices.yAxis);
     }
 
     const dataElement = document.createElement('pre');


### PR DESCRIPTION
The registry profile follows a convention of always using dashes to separate words.  The motion controller library follows the javascript convention of camel case.  This PR fixes the mismatch so that the x/y axes work properly