### PR TITLE
Added a viewer option to force the selected profile to be used in VR.

### DIFF
--- a/packages/viewer/src/index.html
+++ b/packages/viewer/src/index.html
@@ -25,6 +25,9 @@
                     <label for="localFilesSelector">Select local files</label>
                     <input id="localFilesSelector" type="file" multiple>
                     <br>
+                    <label for="forceVRProfile">Force the selected profile to be used in VR</label>
+                    <input type="checkbox" id="forceVRProfile"></input>
+                    <br>
                     <ul id="localFilesList"></ul>
                 </section>
                 <section id="errors" hidden="true">

--- a/packages/viewer/src/mocks/mockXRInputSource.js
+++ b/packages/viewer/src/mocks/mockXRInputSource.js
@@ -6,7 +6,7 @@ class MockXRInputSource {
    * @param {Object} gamepad - The Gamepad object that provides the button and axis data
    * @param {string} handedness - The handedness to report
    */
-  constructor(gamepad, handedness) {
+  constructor(profiles, gamepad, handedness) {
     this.gamepad = gamepad;
 
     if (!handedness) {
@@ -14,7 +14,7 @@ class MockXRInputSource {
     }
 
     this.handedness = handedness;
-    this.profiles = Object.freeze([this.gamepad.id]);
+    this.profiles = Object.freeze(profiles);
   }
 }
 

--- a/packages/viewer/src/modelViewer.js
+++ b/packages/viewer/src/modelViewer.js
@@ -30,7 +30,14 @@ function initializeVRController(index) {
     const controllerModel = new ControllerModel();
     vrController.add(controllerModel);
 
-    const motionController = await profileSelector.createMotionController(event.data);
+    let xrInputSource = event.data;
+    if (profileSelector.forceVRProfile) {
+      xrInputSource = new MockXRInputSource(
+        [profileSelector.profile.profileId], event.data.gamepad, event.data.handedness
+      );
+    }
+
+    const motionController = await profileSelector.createMotionController(xrInputSource);
     await controllerModel.initialize(motionController);
   });
 
@@ -130,7 +137,9 @@ function onSelectionClear() {
 async function onSelectionChange() {
   onSelectionClear();
   const mockGamepad = new MockGamepad(profileSelector.profile, profileSelector.handedness);
-  const mockXRInputSource = new MockXRInputSource(mockGamepad, profileSelector.handedness);
+  const mockXRInputSource = new MockXRInputSource(
+    [profileSelector.profile.profileId], mockGamepad, profileSelector.handedness
+  );
   mockControllerModel = new ControllerModel(mockXRInputSource);
   three.scene.add(mockControllerModel);
 

--- a/packages/viewer/src/profileSelector.js
+++ b/packages/viewer/src/profileSelector.js
@@ -22,6 +22,8 @@ class ProfileSelector extends EventTarget {
     this.handednessSelectorElement = document.getElementById('handednessSelector');
     this.handednessSelectorElement.addEventListener('change', () => { this.onHandednessChange(); });
 
+    this.forceVRProfileElement = document.getElementById('forceVRProfile');
+
     this.localProfile = new LocalProfile();
     this.localProfile.addEventListener('localprofilechange', (event) => { this.onLocalProfileChange(event); });
 
@@ -163,6 +165,13 @@ class ProfileSelector extends EventTarget {
    */
   onLocalProfileChange() {
     this.populateProfileSelector();
+  }
+
+  /**
+   * Updates the profiles dropdown to ensure local profile is in the list
+   */
+  get forceVRProfile() {
+    return this.forceVRProfileElement.checked;
   }
 
   /**


### PR DESCRIPTION
This option enables some limited testing of profiles for devices you may not have on-hand for things like size, position, and component response. When using a forced profile the handedness and gamepad data from the native device will still be used.

Components in the forced profile will still map to anything the actual device reports, and since common components are standardized it means that things like triggers, touchpads, thumbsticks and squeeze buttons all generally control the right things even with the overridden profile.