### PR TITLE
Add generic-touchscreen input source profile

### DIFF
--- a/packages/registry/profiles/generic/generic-touchscreen.json
+++ b/packages/registry/profiles/generic/generic-touchscreen.json
@@ -1,0 +1,24 @@
+{
+    "profileId" : "generic-touchscreen",
+    "fallbackProfileIds": [],
+    "layouts" : {
+        "none" : {
+            "selectComponentId": "touchscreen",
+            "components": {
+                "touchscreen": { "type": "touchpad" }
+            },
+            "gamepad": {
+                "mapping": "",
+                "buttons": [
+                    null,
+                    null,
+                    "touchscreen"
+                ],
+                "axes":[
+                    { "componentId": "touchscreen", "axis": "x-axis"},
+                    { "componentId": "touchscreen", "axis": "y-axis"}
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
It's based on generic-touchpad profile - we could reuse it as-is, but it's
probably better to have a separate profile in this case as touchscreen and
touchpad are conceptually different.

The touchscreen could expose a gamepad object - this should make it easier
for the apps to compute screen space coordinates of the touched point, or
use the values as-is if that's sufficient for their use case.

Closes: immersive-web/hit-test#69.

@toji - please take a look!