### PR TITLE
Added a profile for the HTC Vive Cosmos controller

### DIFF
--- a/packages/registry/profiles/htc/htc-vive-cosmos.json
+++ b/packages/registry/profiles/htc/htc-vive-cosmos.json
@@ -1,0 +1,64 @@
+{
+    "profileId": "htc-vive-cosmos",
+    "fallbackProfileIds": [ "generic-trigger-squeeze-thumbstick" ],
+    "layouts": {
+        "left": {
+            "selectComponentId": "xr-standard-trigger",
+            "components": {
+                "xr-standard-trigger": { "type": "trigger" },
+                "xr-standard-squeeze": { "type": "squeeze" },
+                "xr-standard-thumbstick": { "type": "thumbstick" },
+                "x-button" : { "type": "button" },
+                "y-button" : { "type": "button" },
+                "bumper" : { "type": "button" }
+            },
+            "gamepad": {
+                "mapping": "xr-standard",
+                "buttons": [
+                    "xr-standard-trigger",
+                    "xr-standard-squeeze",
+                    null,
+                    "xr-standard-thumbstick",
+                    "x-button",
+                    "y-button",
+                    "bumper"
+                ],
+                "axes":[
+                    null,
+                    null,
+                    { "componentId": "xr-standard-thumbstick", "axis": "x-axis"},
+                    { "componentId": "xr-standard-thumbstick", "axis": "y-axis"}
+                ]
+            }
+        },
+        "right": {
+            "selectComponentId": "xr-standard-trigger",
+            "components": {
+                "xr-standard-trigger": { "type": "trigger" },
+                "xr-standard-squeeze": { "type": "squeeze" },
+                "xr-standard-thumbstick": { "type": "thumbstick" },
+                "a-button" : { "type": "button" },
+                "b-button" : { "type": "button" },
+                "bumper" : { "type": "button" }
+            },
+            "gamepad": {
+                "mapping": "xr-standard",
+                "buttons": [
+                    "xr-standard-trigger",
+                    "xr-standard-squeeze",
+                    null,
+                    "xr-standard-thumbstick",
+                    "a-button",
+                    "b-button",
+                    "bumper"
+                ],
+                "axes":[
+                    null,
+                    null,
+                    { "componentId": "xr-standard-thumbstick", "axis": "x-axis"},
+                    { "componentId": "xr-standard-thumbstick", "axis": "y-axis"}
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This controller mimics the layout of the Oculus Touch so completely that I really wanted to add that as a fallback profile, but I'm not sure we really want to be doing cross-manufacturer fallbacks without the orgs explicit OK. Plus, then (according to #79) we'd have to put in a placeholder for the thumbrest and I think it makes a lot more sense to use that slot for the unique "bumper" triggers.