### PR TITLE
Enable profiles to indicate deprecated ids

### DIFF
--- a/packages/assets/gulpTasks/writeProfilesListTask.js
+++ b/packages/assets/gulpTasks/writeProfilesListTask.js
@@ -2,8 +2,11 @@ const path = require('path');
 const fs = require('fs-extra');
 const glob = require('glob');
 
+const optionalRequire = require('optional-require')(require);
+
 const taskPaths = require('./taskPaths');
 
+const registryModulePath = optionalRequire.resolve('@webxr-input-profiles/registry', '');
 const profilesListDest = path.join(taskPaths.profilesDest, 'profilesList.json');
 
 function generate() {
@@ -16,7 +19,21 @@ function generate() {
         files.forEach((file) => {
           const profileId = path.basename(path.dirname(file));
           const relativePath = file.substr((taskPaths.profilesSrc.length) + 1);
-          profilesList[profileId] = relativePath;
+          profilesList[profileId] = { path: relativePath };
+
+          // If there are any deprecated profile ids listed in the registry file,
+          // list them as pointing to the same path as the standard profile id.
+          const vendorId = profileId.split('-', 1)[0];
+          const registryFolder = path.join(path.dirname(registryModulePath), 'profiles');
+          const registryJson = fs.readJsonSync(path.join(registryFolder, vendorId, `${profileId}.json`));
+          if (registryJson.deprecatedProfileIds) {
+            registryJson.deprecatedProfileIds.forEach((deprecatedId) => {
+              profilesList[deprecatedId] = {
+                path: relativePath,
+                deprecated: true
+              };
+            });
+          }
         });
 
         resolve(profilesList);

--- a/packages/motion-controllers/src/__tests__/profiles.test.js
+++ b/packages/motion-controllers/src/__tests__/profiles.test.js
@@ -17,7 +17,7 @@ const validProfile = {
 };
 
 const profilesList = {
-  [validProfileId]: `${validProfileId}/profile.json`
+  [validProfileId]: { path: `${validProfileId}/profile.json` }
 };
 
 function buildXRInputSource(profiles = [], handedness = Constants.Handedness.NONE) {

--- a/packages/motion-controllers/src/profiles.js
+++ b/packages/motion-controllers/src/profiles.js
@@ -36,11 +36,12 @@ async function fetchProfile(xrInputSource, basePath, getAssetPath = true) {
   // Find the relative path to the first requested profile that is recognized
   let match;
   xrInputSource.profiles.some((profileId) => {
-    const relativePath = supportedProfilesList[profileId];
-    if (relativePath) {
+    const profile = supportedProfilesList[profileId];
+    if (profile) {
       match = {
         profileId,
-        profilePath: `${basePath}/${relativePath}`
+        profilePath: `${basePath}/${profile.path}`,
+        deprecated: !!profile.deprecated
       };
     }
     return !!match;

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -72,6 +72,18 @@ For example
 
 The `XRInputSource.profiles` array is comprised of these two properties; the `profileId` is the first element followed by the elements in the `fallbackProfileIds` property.
 
+### Deprecated profile ids
+In some cases an input source may have been identified by a non-standard profile id in the past or in some user agents. These can be listed in the `deprecatedProfileIds` array, which will cause those ids to be associated with the correct profile and assets so that user agents advertising the non-standard id still provide users with the right resources.
+
+```json
+{
+    "profileId" : "vendorprefix-profileid",
+    "deprecatedProfileIds" : ["vendorprefix-oldprofileid"]
+}
+```
+
+User agents should always prefer reporting the standard profile ids, and should not intentionally report deprecated ids, even as a fallback profile. User agents that currently report a deprecated profile id should make an effort to change to the standard profile id instead. 
+
 ### Layouts
 Profiles are required to have a `layouts` property which contains the layouts for each supported `handedness`. The `layouts` property must have one, and only one, of the following arrangements of keys to be considered valid:
 * `none`

--- a/packages/registry/gulpTasks/writeProfilesListTask.js
+++ b/packages/registry/gulpTasks/writeProfilesListTask.js
@@ -14,7 +14,19 @@ function generate() {
         files.forEach((file) => {
           const profileId = path.basename(file, '.json');
           const relativePath = file.substr((taskPaths.profilesSrc.length) + 1);
-          profilesList[profileId] = relativePath;
+          profilesList[profileId] = { path: relativePath };
+
+          // If there are any deprecated profile ids listed in the file, list
+          // them as pointing to the same path as the standard profile id.
+          const profileJson = fs.readJsonSync(file);
+          if (profileJson.deprecatedProfileIds) {
+            profileJson.deprecatedProfileIds.forEach((deprecatedId) => {
+              profilesList[deprecatedId] = {
+                path: relativePath,
+                deprecated: true
+              };
+            });
+          }
         });
 
         resolve(profilesList);

--- a/packages/registry/profiles/microsoft/microsoft-mixed-reality.json
+++ b/packages/registry/profiles/microsoft/microsoft-mixed-reality.json
@@ -1,6 +1,7 @@
 {
     "profileId": "microsoft-mixed-reality",
     "fallbackProfileIds": [ "generic-trigger-squeeze-touchpad-thumbstick"],
+    "deprecatedProfileIds": [ "windows-mixed-reality" ],
     "layouts" : {
         "left-right" : {
             "selectComponentId": "xr-standard-trigger",

--- a/packages/registry/schemas/profile.schema.json
+++ b/packages/registry/schemas/profile.schema.json
@@ -12,6 +12,11 @@
             "items": { "$ref": "common.schema.json#/definitions/profileId" },
             "uniqueItems": true
         },
+        "deprecatedProfileIds" : {
+            "type": "array",
+            "items": { "$ref": "common.schema.json#/definitions/profileId" },
+            "uniqueItems": true
+        },
         "layouts" : {
             "type": "object",
             "additionalProperties": false,

--- a/packages/viewer/src/profileSelector.js
+++ b/packages/viewer/src/profileSelector.js
@@ -66,9 +66,12 @@ class ProfileSelector extends EventTarget {
     // Add each profile to the dropdown
     this.profileIdSelectorElement.innerHTML = '';
     Object.keys(this.profilesList).forEach((profileId) => {
-      this.profileIdSelectorElement.innerHTML += `
-      <option value='${profileId}'>${profileId}</option>
-      `;
+      const profile = this.profilesList[profileId];
+      if (!profile.deprecated) {
+        this.profileIdSelectorElement.innerHTML += `
+        <option value='${profileId}'>${profileId}</option>
+        `;
+      }
     });
 
     // Add the local profile if it isn't already included


### PR DESCRIPTION
/fixes #116

For cases where user agents report a non-standard name for some period
of time (which has already been the case with at least one profile in
Chrome) the deprecatedProfileIds let us identify a profile id as being
associated with the assets without implying that it's a registered
profile id.

This PR changes the format of the profilesList.json files to make each
value a dictionary with a `path` key rather than just a string. This
allows us to also report that a particular id is deprecated (so we can
skip it for uses like the profile viewer). I suspect we'll find it
useful in the future for additional metadata as well.