### PR TITLE
Add typescript definitions and checks to the build process

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
     "rules": {
         "linebreak-style": ["warn", "unix"],
         "comma-dangle": ["error", "never"],
-        "import/no-extraneous-dependencies": ["error", {"packageDir": "./"}]
+        "import/no-extraneous-dependencies": ["error", {"packageDir": "./"}],
+        "import/prefer-default-export": ["none"]
     },
     "overrides": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2658,6 +2658,12 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/fetch-mock": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.2.tgz",
+      "integrity": "sha512-NCEfv49jmDsBAixjMjEHKVgmVQlJ+uK56FOc+2roYPExnXCZDpi6mJOHQ3v23BiO84hBDStND9R2itJr7PNoow==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -2692,6 +2698,15 @@
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.0.tgz",
+      "integrity": "sha512-dXvuABY9nM1xgsXlOtLQXJKdacxZJd7AtvLsKZ/0b57ruMXDKCOXAC/M75GbllQX6o1pcZ5hAG4JzYy7Z/wM2w==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^24.3.0"
       }
     },
     "@types/json-schema": {
@@ -3281,6 +3296,24 @@
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
       }
     },
     "bach": {
@@ -4239,6 +4272,12 @@
         "is-plain-object": "^2.0.1"
       }
     },
+    "core-js": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+      "dev": true
+    },
     "core-js-compat": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
@@ -4297,16 +4336,6 @@
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
-      }
-    },
-    "cross-fetch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.1.2",
-        "whatwg-fetch": "2.0.4"
       }
     },
     "cross-spawn": {
@@ -5449,6 +5478,29 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
+      }
+    },
+    "fetch-mock": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.3.1.tgz",
+      "integrity": "sha512-7IEIUvkHO6zOHbDSzkMAvkb2mx3N5xy9BS4RjFnIe8kCUDOomoNKBDKGwhTj5E0uuieo8rg55c6cUKorJuk4rg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^3.0.0",
+        "glob-to-regexp": "^0.4.0",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+          "dev": true
+        }
       }
     },
     "figgy-pudding": {
@@ -8206,16 +8258,6 @@
         "jest-util": "^24.9.0"
       }
     },
-    "jest-fetch-mock": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
-      "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^2.2.2",
-        "promise-polyfill": "^7.1.1"
-      }
-    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
@@ -8910,6 +8952,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -9500,9 +9548,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
     },
     "node-fetch-npm": {
@@ -10229,6 +10277,12 @@
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -10482,12 +10536,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
-      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
-      "dev": true
-    },
     "promise-retry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
@@ -10593,6 +10641,12 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
       "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "quick-lru": {
@@ -10756,6 +10810,12 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -12137,6 +12197,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -12552,12 +12618,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -42,29 +42,33 @@
     "dev": "http-server ./packages/viewer/dist -c-1 -p 8080",
     "prepublishOnly": "npm run clean && npm run lint && npm run build",
     "pretest": "npm run prepublishOnly",
-    "test": "npm run testOnly"
+    "test": "npx lerna run typecheck && npm run testOnly"
   },
   "devDependencies": {
     "@babel/plugin-transform-spread": "^7.2.2",
     "@babel/preset-env": "^7.3.4",
+    "@types/fetch-mock": "^7.3.2",
+    "@types/jest": "^24.9.0",
     "ajv": "^6.10.0",
     "babel-jest": "^24.1.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-jest": "^22.15.2",
+    "fetch-mock": "^8.3.1",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
     "gulp": "^4.0.2",
     "gulp-jsoncombine": "^1.0.4",
     "http-server": "^0.11.1",
     "jest": "^24.1.0",
-    "jest-fetch-mock": "^2.1.2",
     "lerna": "^3.16.4",
+    "node-fetch": "^2.6.0",
     "optional-require": "^1.0.0",
     "rollup": "^1.4.0",
     "rollup-plugin-copy-glob": "^0.3.1",
     "three": "^0.112.0",
-    "through2": "^3.0.1"
+    "through2": "^3.0.1",
+    "typescript": "^3.7.5"
   }
 }

--- a/packages/motion-controllers/package.json
+++ b/packages/motion-controllers/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "",
   "main": "dist/motion-controllers.module.js",
+  "types": "src/index.d.ts",
   "files": [
     "package.json",
     "LICENSE",
@@ -13,11 +14,12 @@
   ],
   "scripts": {
     "clean": "node -e \"try { require('fs').rmdirSync('./dist', { recursive: true }); } catch {}\"",
-      "badClean": "rm -r dist 2> /dev/null || true",
+    "badClean": "rm -r dist 2> /dev/null || true",
     "build": "rollup -c",
     "cleanBuild": "npm run clean && npm run build",
     "watch": "rollup -c -w -m inline",
-    "test": "echo \"Run tests from root\" && exit 1"
+    "test": "echo \"Run tests from root\" && exit 1",
+    "typecheck": "tsc -p tsconfig.json"
   },
   "devDependencies": {
     "@webxr-input-profiles/assets": "^0.1.0"

--- a/packages/motion-controllers/src/__tests__/component.test.js
+++ b/packages/motion-controllers/src/__tests__/component.test.js
@@ -1,5 +1,5 @@
-import Constants from '../constants';
-import Component from '../components';
+import { Constants } from '../constants';
+import { Component } from '../components';
 
 const buttonComponent = {
   id: 'buttonComponent',

--- a/packages/motion-controllers/src/__tests__/motionController.test.js
+++ b/packages/motion-controllers/src/__tests__/motionController.test.js
@@ -1,5 +1,5 @@
-import Constants from '../constants';
-import MotionController from '../motionController';
+import { Constants } from '../constants';
+import { MotionController } from '../motionController';
 
 const profile = {
   id: 'mock-one-button',

--- a/packages/motion-controllers/src/__tests__/visualResponse.test.js
+++ b/packages/motion-controllers/src/__tests__/visualResponse.test.js
@@ -1,5 +1,5 @@
-import Constants from '../constants';
-import VisualResponse from '../visualResponse';
+import { Constants } from '../constants';
+import { VisualResponse } from '../visualResponse';
 
 describe('Construction tests', () => {
   test('Fail to construct visual response when description is not provided', () => {

--- a/packages/motion-controllers/src/component.d.ts
+++ b/packages/motion-controllers/src/component.d.ts
@@ -1,0 +1,23 @@
+import { Constants } from './constants';
+import { VisualResponse } from './visualResponse';
+
+export class Component {
+  constructor(componentId: string, componentDescription: object);
+
+  readonly id: string;
+  readonly type: Constants.ComponentType;
+  readonly rootNodeName: string;
+  readonly touchPointNodeName: string;
+
+  readonly visualResponses: { [key: string]: VisualResponse };
+  readonly gamepadIndices: { button: number; xAxis: number; yAxis: number };
+  readonly values: { 
+    state: Constants.ComponentState; 
+    button?: number; 
+    xAxis?: number; 
+    yAxis?: number };
+
+  get data(): object;
+
+  updateFromGamepad(gamepad: Gamepad): void;
+}

--- a/packages/motion-controllers/src/components.js
+++ b/packages/motion-controllers/src/components.js
@@ -1,5 +1,5 @@
-import Constants from './constants';
-import VisualResponse from './visualResponse';
+import { Constants } from './constants';
+import { VisualResponse } from './visualResponse';
 
 class Component {
   /**
@@ -102,4 +102,4 @@ class Component {
   }
 }
 
-export default Component;
+export { Component };

--- a/packages/motion-controllers/src/constants.d.ts
+++ b/packages/motion-controllers/src/constants.d.ts
@@ -1,0 +1,36 @@
+export namespace Constants {
+  export const enum Handedness {
+    NONE,
+    LEFT,
+    RIGHT
+  }
+
+  export const enum ComponentState {
+    DEFAULT,
+    TOUCHED,
+    PRESSED
+  }
+
+  export const enum ComponentProperty {
+    BUTTON,
+    X_AXIS,
+    Y_AXIS,
+    STATE
+  }
+
+  export const enum ComponentType {
+    TRIGGER,
+    SQUEEZE,
+    TOUCHPAD,
+    THUMBSTICK,
+    BUTTON
+  }
+
+  export const ButtonTouchThreshold: number;
+  export const AxisTouchThreshold: number;
+
+  export const enum VisualResponseProperty {
+    TRANSFORM,
+    VISIBILITY
+  }
+}

--- a/packages/motion-controllers/src/constants.js
+++ b/packages/motion-controllers/src/constants.js
@@ -36,4 +36,4 @@ const Constants = {
   })
 };
 
-export default Constants;
+export { Constants };

--- a/packages/motion-controllers/src/index.d.ts
+++ b/packages/motion-controllers/src/index.d.ts
@@ -1,0 +1,7 @@
+export * from './constants';
+export * from './profiles';
+export * from './motionController';
+export * from './component';
+export * from './visualResponse';
+
+export as namespace WebXRInputProfiles;

--- a/packages/motion-controllers/src/index.js
+++ b/packages/motion-controllers/src/index.js
@@ -1,3 +1,3 @@
-export { default as Constants } from './constants';
+export { Constants } from './constants';
 export { fetchProfile, fetchProfilesList } from './profiles';
-export { default as MotionController } from './motionController';
+export { MotionController } from './motionController';

--- a/packages/motion-controllers/src/motionController.d.ts
+++ b/packages/motion-controllers/src/motionController.d.ts
@@ -1,0 +1,14 @@
+import { Component } from "./component";
+
+export class MotionController {
+  constructor(xrInputSource: object, profile: object, assetUrl: string);
+
+  readonly xrInputSource: object;
+  readonly assetUrl: string;
+  readonly id: string;
+  readonly components: { [key: string]: Component };
+
+  get data(): object;
+
+  updateFromGamepad(): void;
+}

--- a/packages/motion-controllers/src/motionController.js
+++ b/packages/motion-controllers/src/motionController.js
@@ -1,4 +1,4 @@
-import Component from './components';
+import { Component } from './components';
 
 /**
   * @description Builds a motion controller with components and visual responses based on the
@@ -65,4 +65,4 @@ class MotionController {
   }
 }
 
-export default MotionController;
+export { MotionController };

--- a/packages/motion-controllers/src/profiles.d.ts
+++ b/packages/motion-controllers/src/profiles.d.ts
@@ -1,0 +1,9 @@
+export as namespace Profiles;
+
+export function fetchProfilesList(basePath: string): { [key: string]: string };
+export function fetchProfile(
+  xrInputSource: object,
+  basePath: string,
+  defaultProfileId?: string,
+  getAssetPath?: boolean
+): { profile: object; assetPath?: string };

--- a/packages/motion-controllers/src/visualResponse.d.ts
+++ b/packages/motion-controllers/src/visualResponse.d.ts
@@ -1,0 +1,23 @@
+import { Component } from './component';
+import { Constants } from './constants';
+
+export class VisualResponse {
+  constructor(visualResponseDescription: object);
+
+  readonly componentProperty: Constants.ComponentProperty;
+  readonly states: [Constants.ComponentState];
+  readonly valueNodeName: string;
+  readonly valueNodeProperty: Constants.VisualResponseProperty;
+
+  readonly minNodeName?: string;
+  readonly maxNodeName?: string;
+
+  readonly value: number | boolean;
+
+  updateFromComponent(component: { 
+    state: Constants.ComponentState;
+    button?: number;
+    xAxis?: number;
+    yAxis?: number 
+  }): void;
+}

--- a/packages/motion-controllers/src/visualResponse.js
+++ b/packages/motion-controllers/src/visualResponse.js
@@ -1,4 +1,4 @@
-import Constants from './constants';
+import { Constants } from './constants';
 
 /** @constant {Object} */
 const defaultComponentValues = {
@@ -65,7 +65,7 @@ class VisualResponse {
 
   /**
    * Computes the visual response's interpolation weight based on component state
-   * @param {Object} component - The component from which to update
+   * @param {Object} componentValues - The component from which to update
    * @param {number} xAxis - The reported X axis value of the component
    * @param {number} yAxis - The reported Y axis value of the component
    * @param {number} button - The reported value of the component's button
@@ -98,4 +98,4 @@ class VisualResponse {
   }
 }
 
-export default VisualResponse;
+export { VisualResponse };

--- a/packages/motion-controllers/tsconfig.json
+++ b/packages/motion-controllers/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "target": "ES5"
+  },
+  "include": ["./src/*.d.ts", "./src/__tests__/*.js"],
+}

--- a/packages/viewer/src/mocks/mockGamepad.js
+++ b/packages/viewer/src/mocks/mockGamepad.js
@@ -1,4 +1,6 @@
-import Constants from '../../../motion-controllers/src/constants.js';
+/* eslint-disable import/no-unresolved */
+import { Constants } from '../motion-controllers.module.js';
+/* eslint-enable */
 
 /**
  * A false gamepad to be used in tests

--- a/packages/viewer/src/profileSelector.js
+++ b/packages/viewer/src/profileSelector.js
@@ -109,7 +109,7 @@ class ProfileSelector extends EventTarget {
       // Attempt to load the profile
       this.profileIdSelectorElement.disabled = true;
       this.handednessSelectorElement.disabled = true;
-      fetchProfile({ profiles: [profileId], handedness: 'any' }, profilesBasePath, false).then(({ profile }) => {
+      fetchProfile({ profiles: [profileId], handedness: 'any' }, profilesBasePath, null, false).then(({ profile }) => {
         this.profile = profile;
         this.populateHandednessSelector();
       })


### PR DESCRIPTION
Was puttering on my just-for-fun project and really needed those typescript definitions so I created them.  Seemed silly not to submit a PR for adding them to the package just because I'm on leave.  So...

Fixes #149 by adding *.d.ts files that match the exports of the motion-controllers library.  To ensure that these definition files stay in sync with the javascript, the build has been updated to validate the signatures against the existing unit tests.  In order to get this working, jest-fetch-mock was replaced by fetch-mock because the latter exposes type definitions in DefinitelyTyped.