### PR TITLE
Updated input profiles to match current OpenXR Chromium implementation

### DIFF
--- a/packages/registry/profiles/htc/htc-vive.json
+++ b/packages/registry/profiles/htc/htc-vive.json
@@ -8,7 +8,7 @@
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
-                "menu" : { "type": "button" }
+                "menu" : { "type": "button", reserved: true }
             },
             "gamepad" : {
                 "mapping": "xr-standard",
@@ -16,8 +16,7 @@
                     "xr-standard-trigger",
                     "xr-standard-squeeze",
                     "xr-standard-touchpad",
-                    null,
-                    "menu"
+                    null
                 ],
                 "axes":[
                     { "componentId": "xr-standard-touchpad", "axis": "x-axis"},

--- a/packages/registry/profiles/htc/htc-vive.json
+++ b/packages/registry/profiles/htc/htc-vive.json
@@ -8,7 +8,7 @@
                 "xr-standard-trigger": { "type": "trigger" },
                 "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
-                "menu" : { "type": "button", reserved: true }
+                "menu" : { "type": "button", "reserved": true }
             },
             "gamepad" : {
                 "mapping": "xr-standard",

--- a/packages/registry/profiles/oculus/oculus-touch-v2.json
+++ b/packages/registry/profiles/oculus/oculus-touch-v2.json
@@ -10,7 +10,8 @@
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "x-button" : { "type": "button" },
                 "y-button" : { "type": "button" },
-                "thumbrest" : { "type": "button" }
+                "thumbrest" : { "type": "button" },
+                "menu" : { "type": "button", "reserved": true }
             },
             "gamepad": {
                 "mapping": "xr-standard",

--- a/packages/registry/profiles/oculus/oculus-touch.json
+++ b/packages/registry/profiles/oculus/oculus-touch.json
@@ -10,7 +10,8 @@
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "x-button" : { "type": "button" },
                 "y-button" : { "type": "button" },
-                "thumbrest" : { "type": "button" }
+                "thumbrest" : { "type": "button" },
+                "menu" : { "type": "button", "reserved": true }
             },
             "gamepad": {
                 "mapping": "xr-standard",

--- a/packages/registry/profiles/samsung/samsung-odyssey.json
+++ b/packages/registry/profiles/samsung/samsung-odyssey.json
@@ -9,7 +9,7 @@
                 "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
-                "menu" : { "type": "button", reserved: true }
+                "menu" : { "type": "button", "reserved": true }
             },
             "gamepad" : {
                 "mapping": "xr-standard",

--- a/packages/registry/profiles/samsung/samsung-odyssey.json
+++ b/packages/registry/profiles/samsung/samsung-odyssey.json
@@ -9,7 +9,7 @@
                 "xr-standard-squeeze": { "type": "squeeze" },
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
-                "menu" : { "type": "button" }
+                "menu" : { "type": "button", reserved: true }
             },
             "gamepad" : {
                 "mapping": "xr-standard",

--- a/packages/registry/profiles/valve/valve-index.json
+++ b/packages/registry/profiles/valve/valve-index.json
@@ -10,7 +10,7 @@
                 "xr-standard-touchpad": { "type": "touchpad" },
                 "xr-standard-thumbstick": { "type": "thumbstick" },
                 "a-button" : { "type": "button" },
-                "b-button" : { "type": "button" }
+                "b-button" : { "type": "button", "reserved": true }
             },
             "gamepad": {
                 "mapping": "xr-standard",

--- a/packages/registry/profiles/valve/valve-index.json
+++ b/packages/registry/profiles/valve/valve-index.json
@@ -19,8 +19,7 @@
                     "xr-standard-squeeze",
                     "xr-standard-touchpad",
                     "xr-standard-thumbstick",
-                    "a-button",
-                    "b-button"
+                    "a-button"
                 ],
                 "axes":[
                     { "componentId": "xr-standard-touchpad", "axis": "x-axis"},


### PR DESCRIPTION
Updated the input profiles to match what is currently implemented in the OpenXR implementation of WebXR for Chromium, which has input bindings for all PC VR controllers.

Each input profile has a menu button reserved by the browser.