### PR TITLE
Update google-daydream.json

### DIFF
--- a/packages/registry/profiles/google/google-daydream.json
+++ b/packages/registry/profiles/google/google-daydream.json
@@ -10,8 +10,6 @@
             "gamepad": {
                 "mapping": "",
                 "buttons": [ 
-                    null,
-                    null,
                     "touchpad"
                 ],
                 "axes":[


### PR DESCRIPTION
Daydream button index is 0 and not 2 when using latest chrome

![image](https://user-images.githubusercontent.com/1381702/97319327-105d8b80-186d-11eb-9f6a-88f000dcbcdd.png)

I know daydream is deprecated, but it seems like people are still using it :-) 
