### PR TITLE
Address API changes from three.js r113 -> r127

### DIFF
--- a/packages/viewer/src/controllerModel.js
+++ b/packages/viewer/src/controllerModel.js
@@ -104,10 +104,9 @@ class ControllerModel extends THREE.Object3D {
         } else if (valueNodeProperty === Constants.VisualResponseProperty.TRANSFORM) {
           const minNode = this.nodes[minNodeName];
           const maxNode = this.nodes[maxNodeName];
-          THREE.Quaternion.slerp(
+          valueNode.quaternion.slerpQuaternions(
             minNode.quaternion,
             maxNode.quaternion,
-            valueNode.quaternion,
             value
           );
 

--- a/packages/viewer/src/modelViewer.js
+++ b/packages/viewer/src/modelViewer.js
@@ -133,7 +133,7 @@ function initializeThree() {
   three.scene.background = new THREE.Color(0x00aa44);
   three.renderer = new THREE.WebGLRenderer({ antialias: true });
   three.renderer.setSize(width, height);
-  three.renderer.gammaOutput = true;
+  three.renderer.outputEncoding = THREE.sRGBEncoding;
 
   // Set up the controls for moving the scene around
   three.cameraControls = new OrbitControls(three.camera, three.renderer.domElement);


### PR DESCRIPTION
- Switches from using the static THREE.Quaternion.slerp() method to the instance .slerpQuaternions() method.
- Sets WebGLRenderer.outputEncoding instead of WebGLRenderer.gammaOutput

Just a couple small changes to finally resolve #218 