### PR TITLE
Motion controller: Separate out value updates and visual responses inside component

### DIFF
--- a/packages/motion-controllers/src/component.d.ts
+++ b/packages/motion-controllers/src/component.d.ts
@@ -20,4 +20,5 @@ export class Component {
   get data(): object;
 
   updateFromGamepad(gamepad: Gamepad): void;
+  updateValuesFromGamepad(gamepad: Gamepad): void;
 }

--- a/packages/motion-controllers/src/components.js
+++ b/packages/motion-controllers/src/components.js
@@ -44,10 +44,24 @@ class Component {
   }
 
   /**
-   * @description Poll for updated data based on current gamepad state
+   * @description Poll for updated values and visual response weights based on current gamepad state
    * @param {Object} gamepad - The gamepad object from which the component data should be polled
    */
   updateFromGamepad(gamepad) {
+    // Update the values with latest data from the gamepad
+    this.updateValuesFromGamepad(gamepad);
+
+    // Update the visual response weights based on the current component data
+    Object.values(this.visualResponses).forEach((visualResponse) => {
+      visualResponse.updateFromComponent(this.values);
+    });
+  }
+
+  /**
+   * @description Poll for updated component values based on current gamepad state
+   * @param {Object} gamepad - The gamepad object from which the component values should be polled
+   */
+  updateValuesFromGamepad(gamepad) {
     // Set the state to default before processing other data sources
     this.values.state = Constants.ComponentState.DEFAULT;
 
@@ -94,11 +108,6 @@ class Component {
         this.values.state = Constants.ComponentState.TOUCHED;
       }
     }
-
-    // Update the visual response weights based on the current component data
-    Object.values(this.visualResponses).forEach((visualResponse) => {
-      visualResponse.updateFromComponent(this.values);
-    });
   }
 }
 


### PR DESCRIPTION
Addresses Issue #236

Enhancement to allow for selectively updating only component values from gamepad when updates to visual response weights are not required (for example, when visuals are managed independently with custom models or only value updates are desired to send out custom events)