### PR TITLE
motion-controllers: fix NPM config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 npm-debug*.log*
 lerna*.log
+dist

--- a/packages/motion-controllers/package.json
+++ b/packages/motion-controllers/package.json
@@ -2,14 +2,20 @@
   "name": "@webxr-input-profiles/motion-controllers",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/motion-controllers.js",
-  "module": "dist/motion-controllers.module.js",
-  "types": "src/index.d.ts",
+  "type": "module",
+  "main": "./dist/motion-controllers.cjs",
+  "module": "./dist/motion-controllers.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    "types": "./src/index.d.ts",
+    "require": "./dist/motion-controllers.cjs",
+    "import": "./dist/motion-controllers.js"
+  },
   "files": [
     "package.json",
     "LICENSE",
     "README.md",
-    "dist/motion-controllers.module.js",
+    "dist/**",
     "src/**"
   ],
   "scripts": {

--- a/packages/motion-controllers/rollup.config.js
+++ b/packages/motion-controllers/rollup.config.js
@@ -13,11 +13,11 @@ export default [
     output: [
       {
         format: 'es',
-        file: `${DIST_FOLDER}/motion-controllers.module.js`
+        file: `${DIST_FOLDER}/motion-controllers.js`
       },
       {
         format: 'cjs',
-        file: `${DIST_FOLDER}/motion-controllers.js`
+        file: `${DIST_FOLDER}/motion-controllers.cjs`
       }
     ]
   }


### PR DESCRIPTION
Fixes #250 and configures the `exports` field for Node ESM resolution. `module` is a Webpack convention and is non-standard.

As-is, the package resolves only for CJS which is not currently published on NPM due to the `files` field.

Might be worth adding https://publint.dev CLI to CI or before publish.