### PR TITLE
Fix motion-controllers module path

### DIFF
--- a/packages/motion-controllers/README.md
+++ b/packages/motion-controllers/README.md
@@ -59,7 +59,7 @@ function onInputSourcesChange(event) {
 Creating a `MotionController` requires a JSON profile in the format published by the [assets](../assets/README.md) package and, if available, the path to an associated asset. The `fetchProfile` function can be used to fetch this information for a supplied `XRInputSource` from a supplied `basePath`. It will first fetch the `profilesList.json` file at the root of the `basePath`; this file must contain a JSON object with keys for each available profile id whose values are the relative paths to the profiles' locations. It will then iterate through the `XRInputSource.profiles` array to find the first matching profile and retrieve it.
 
 ```js
-import { fetchProfile, MotionController } from '@webxr-input-profiles/motion-controllers/motion-controllers.module.js'
+import { fetchProfile, MotionController } from '@webxr-input-profiles/motion-controllers/motion-controllers.js'
 
 const uri = 'URI of folder with profiles and assets';
 const motionControllers = {};

--- a/packages/viewer/rollup.config.js
+++ b/packages/viewer/rollup.config.js
@@ -19,8 +19,8 @@ export default [
       './three/examples/jsm/controls/OrbitControls.js',
       './three/examples/jsm/webxr/VRButton.js',
       './ajv/ajv.min.js',
-      './motion-controllers.module.js',
-      '../motion-controllers.module.js',
+      './motion-controllers.js',
+      '../motion-controllers.js',
       './registryTools/validateRegistryProfile.js',
       './assetTools/expandRegistryProfile.js',
       './assetTools/buildAssetProfile.js'

--- a/packages/viewer/src/controllerModel.js
+++ b/packages/viewer/src/controllerModel.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved */
 import * as THREE from './three/build/three.module.js';
 import { GLTFLoader } from './three/examples/jsm/loaders/GLTFLoader.js';
-import { Constants } from './motion-controllers.module.js';
+import { Constants } from './motion-controllers.js';
 /* eslint-enable */
 
 import AssetError from './assetError.js';

--- a/packages/viewer/src/mocks/mockGamepad.js
+++ b/packages/viewer/src/mocks/mockGamepad.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved */
-import { Constants } from '../motion-controllers.module.js';
+import { Constants } from '../motion-controllers.js';
 /* eslint-enable */
 
 /**

--- a/packages/viewer/src/profileSelector.js
+++ b/packages/viewer/src/profileSelector.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved */
-import { fetchProfile, fetchProfilesList, MotionController } from './motion-controllers.module.js';
+import { fetchProfile, fetchProfilesList, MotionController } from './motion-controllers.js';
 /* eslint-enable */
 
 import AssetError from './assetError.js';


### PR DESCRIPTION
Should resolve the viewer problems in issue #254

Following commit https://github.com/immersive-web/webxr-input-profiles/commit/ec044381753a5d00154711b91cf6f50804df6f52
I replaced all instances of `motion-controllers.module.js` with `motion-controllers.js`

I tested using:
```
npm install
npm run build
npm run dev
```
and it works locally