### PR TITLE
add menu button to Quest/Oculus controllers

### DIFF
--- a/packages/registry/profiles/meta/meta-quest-touch-plus.json
+++ b/packages/registry/profiles/meta/meta-quest-touch-plus.json
@@ -15,7 +15,7 @@
         "x-button": { "type": "button" },
         "y-button": { "type": "button" },
         "thumbrest": { "type": "button" },
-        "menu": { "type": "button", "reserved": true }
+        "menu": { "type": "button" }
       },
       "gamepad": {
         "mapping": "xr-standard",
@@ -26,7 +26,8 @@
           "xr-standard-thumbstick",
           "x-button",
           "y-button",
-          "thumbrest"
+          "thumbrest",
+          "menu"
         ],
         "axes": [
           null,

--- a/packages/registry/profiles/meta/meta-quest-touch-pro.json
+++ b/packages/registry/profiles/meta/meta-quest-touch-pro.json
@@ -15,7 +15,7 @@
         "x-button": { "type": "button" },
         "y-button": { "type": "button" },
         "thumbrest": { "type": "button" },
-        "menu": { "type": "button", "reserved": true }
+        "menu": { "type": "button" }
       },
       "gamepad": {
         "mapping": "xr-standard",
@@ -26,7 +26,8 @@
           "xr-standard-thumbstick",
           "x-button",
           "y-button",
-          "thumbrest"
+          "thumbrest",
+          "menu"
         ],
         "axes": [
           null,

--- a/packages/registry/profiles/oculus/oculus-hand.json
+++ b/packages/registry/profiles/oculus/oculus-hand.json
@@ -1,0 +1,40 @@
+{
+    "profileId" : "oculus-hand",
+    "fallbackProfileIds": [
+        "generic-hand",
+        "generic-hand-select"
+    ],
+    "layouts" : {
+        "left" : {
+            "selectComponentId": "xr-standard-trigger",
+            "components": {
+                "xr-standard-trigger": { "type": "trigger" },
+                "menu": { "type": "button" }
+            },
+            "gamepad": {
+                "mapping": "xr-standard",
+                "buttons": [
+                    "xr-standard-trigger",
+                    null,
+                    null,
+                    null,
+                    "menu"
+                ],
+                "axes":[]
+            }
+        },
+        "right" : {
+            "selectComponentId": "xr-standard-trigger",
+            "components": {
+                "xr-standard-trigger": { "type": "trigger" }
+            },
+            "gamepad": {
+                "mapping": "xr-standard",
+                "buttons": [
+                    "xr-standard-trigger"
+                ],
+                "axes":[]
+            }
+        }
+    }
+}

--- a/packages/registry/profiles/oculus/oculus-touch-v3.json
+++ b/packages/registry/profiles/oculus/oculus-touch-v3.json
@@ -11,7 +11,7 @@
                 "x-button" : { "type": "button" },
                 "y-button" : { "type": "button" },
                 "thumbrest" : { "type": "button" },
-                "menu" : { "type": "button", "reserved": true }
+                "menu" : { "type": "button" }
             },
             "gamepad": {
                 "mapping": "xr-standard",
@@ -22,7 +22,8 @@
                     "xr-standard-thumbstick",
                     "x-button",
                     "y-button",
-                    "thumbrest"
+                    "thumbrest",
+                    "menu"
                 ],
                 "axes":[
                     null,


### PR DESCRIPTION
An upcoming version of the Quest browser will no longer exit WebXR when the menu button is clicked.
This will enable us to add support for this button to controllers and hands.
